### PR TITLE
Update NavSecondary hover-state

### DIFF
--- a/components/NavSecondary.vue
+++ b/components/NavSecondary.vue
@@ -45,6 +45,7 @@ export default {
         margin: 0;
         padding: 0;
     }
+
     .list-item {
         display: inline-block;
         margin-left: 50px;
@@ -55,18 +56,17 @@ export default {
             margin-left: 0;
         }
     }
+
     .link {
         color: var(--color-black);
         text-decoration: none;
     }
 
     // Hover states
-    @media (hover: hover) {
-        .link {
-            &:hover,
-            &:active {
-                color: var(--color-primary-blue);
-            }
+    @media #{$has-hover} {
+        .link:hover,
+        .link:active {
+            color: var(--color-primary-blue);
         }
     }
 }


### PR DESCRIPTION
Update the hover state in NavSecondary because of the recent updates in: [Setup SCSS vars for breakpoints and hover media queries](https://github.com/UCLALibrary/library-website-nuxt/commit/cca414f75ff89fb29485bf04808a9e4114438d3e)

```scss
// Breakpoints
$gt-wide: "only screen and (min-width: 1800px)";
$lte-tablet: "only screen and (max-width: 1024px)";
$lte-phone: "only screen and (max-width: 750px)";
$lte-phone-landscape: "only screen and (max-width: 750px) and (orientation: landscape)";
$has-hover: "(hover: hover)";
```

---

Changes to be committed:
modified:
+ `components/NavSecondary.vue`

