### PR TITLE
Add missing nuxt to props.

### DIFF
--- a/components/SectionDualMasonry.vue
+++ b/components/SectionDualMasonry.vue
@@ -40,6 +40,10 @@ export default {
             type: Array,
             default: () => [],
         },
+        to: {
+            type: String,
+            default: "",
+        },
     },
 }
 </script>


### PR DESCRIPTION
This PR adds missing prop `to`  on SectionDualMasonry component.