### PR TITLE
index not needed in v-for on linkItems

### DIFF
--- a/components/SearchHome.vue
+++ b/components/SearchHome.vue
@@ -41,7 +41,7 @@
                     class="regular-links"
                 >
                     <a
-                        v-for="(link, i) in linkItems"
+                        v-for="link in linkItems"
                         :key="link.url"
                         class="link"
                         :href="link.url"


### PR DESCRIPTION
Small change for #47. See comment: https://github.com/UCLALibrary/library-website-nuxt/pull/77#discussion_r645727618
