### PR TITLE
APPS-917 Center Primary Event Box on home page

### DIFF
--- a/components/BannerFeatured.vue
+++ b/components/BannerFeatured.vue
@@ -269,8 +269,8 @@ export default {
             0 0,
             calc(100% - 39px) 0,
             100% 95px,
-            100% 100%,
-            0 100%
+            100% 102%,
+            0 102%
         );
     }
     .hatch {
@@ -363,7 +363,7 @@ export default {
             margin-left: auto;
             padding-right: 50px;
             padding-left: 100px;
-            clip-path: polygon(39px 0, 100% 0, 100% 100%, 0 100%, 0% 95px);
+            clip-path: polygon(39px 0, 105% 0, 100% 102%, 0 102%, 0% 95px);
         }
         .hatch {
             right: calc(65% - 99px);

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -28,6 +28,7 @@
             :is-online="bannerVisit.isOnline"
             :prompt="bannerVisit.prompt"
             :ratio="bannerVisit.ratio"
+            :align-right="false"
         >
             <heading-arrow
                 :text="bannerVisit.breadcrumb.text"


### PR DESCRIPTION
Connected to [APPS-917](https://jira.library.ucla.edu/browse/APPS-917)

This PR centers the Primary Event Box on the home Page and adjusts clippy arguments to hide the image from showing under the clipped box.