### PR TITLE
In SectionCards, expand the "more" card on hover.

### DIFF
--- a/components/SectionCards.vue
+++ b/components/SectionCards.vue
@@ -108,6 +108,10 @@ export default {
         border-radius: var(--rounded-slightly-all);
         box-sizing: border-box;
 
+        transition-property: box-shadow, transform;
+        transition-duration: 400ms;
+        transition-timing-function: ease-in-out;
+
         display: flex;
         flex-direction: column;
         flex-wrap: nowrap;
@@ -119,6 +123,16 @@ export default {
             width: 100%;
             max-width: 100%;
             height: 100%;
+        }
+    }
+
+    // Hovers
+    .card-more {
+        @media #{$has-hover} {
+            &:hover {
+                transform: scale(1.1);
+                box-shadow: 0px 10px 17px rgba(0, 0, 0, 0.04);
+            }
         }
     }
 


### PR DESCRIPTION
closes https://github.com/UCLALibrary/library-website-nuxt/issues/76
closes https://jira.library.ucla.edu/browse/APPS-926

**Stories:** ~/stories/{filename}.stories.js

**Notes:**

Implemented this the easy way, copying CSS from BlockCardVertical. A little messy, but :shrug:.

**Time Report:**

This took me 1/4 hours to build this.

**Checklist:**

-   [/] I double checked it looks like the designs
-   [/] I completed any required mobile breakpoint styling
-   [/] I completed any required hover state styling
-   [/] I included a working Storybook file
-   [/] I included a Story that showed some edge case working correctly (long text, short screen, missing image etc.)
-   [/] I added notes above about how long it took to build this component
-   [/] I assigned this PR to someone to review
