### PR TITLE
Remove color from arrow-right.svg

### DIFF
--- a/assets/svg/arrow-right.svg
+++ b/assets/svg/arrow-right.svg
@@ -1,4 +1,4 @@
 <svg width="49" height="49" viewBox="0 0 49 49" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M14.7959 24.1055L41.2959 24.1055" stroke="#0F0F0F" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="round"/>
-<path d="M28.7959 38.1055L42.7959 24.1055L28.7959 10.1055" stroke="#0F0F0F" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="round"/>
+<path d="M14.7959 24.1055L41.2959 24.1055" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="round"/>
+<path d="M28.7959 38.1055L42.7959 24.1055L28.7959 10.1055" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="round"/>
 </svg>


### PR DESCRIPTION
TO DO:
-[ ] fill out this PR description
-[ ] Make sure the arrow gets a color in CSS everywhere it gets used (will probably have to add to footer)

Since a color set explicitly in the svg takes precedence, it must be removed in order for the path color to be set via CSS (which we need to do, for example, with the ButtonMore hover state).

**Component Created:** {filename}.vue from #{issue number}

**Stories:** ~/stories/{filename}.stories.js

**Notes:**

{Any notes about what you built. How does it work? Anything missing?}

**Time Report:**

This took me {x} hours to build this.

**Checklist:**

-   [ ] I double checked it looks like the designs
-   [ ] I completed any required mobile breakpoint styling
-   [ ] I completed any required hover state styling
-   [ ] I included a working Storybook file
-   [ ] I included a Story that showed some edge case working correctly (long text, short screen, missing image etc.)
-   [ ] I added notes above about how long it took to build this component
-   [ ] I assigned this PR to someone to review
