### PR TITLE
Single screen width for percy-storybook snapshots

### DIFF
--- a/.percy.yml
+++ b/.percy.yml
@@ -1,0 +1,3 @@
+version: 2
+snapshot:
+  widths: [1440]


### PR DESCRIPTION
To save on our percy screenshot allowance, snapshot storybook stories at 1440px only.

When we add cypress tests of the built website, we will want to add a few screenshots, we will want to add a few screenshots with multiple widths to test responsive behavior. (Also multiple browsers).