### PR TITLE
Use different Percy tokens for e2e, storybook

### DIFF
--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -32,7 +32,7 @@ jobs:
       if: steps.cache-storybook.outputs.cache-hit != 'true'
     - run: npm run percy-static
       env: 
-        PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+        PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_STORYBOOK }}
 
   percy-cypress:
     name: Cypress tests with Percy screenshots
@@ -59,4 +59,4 @@ jobs:
         command-prefix: 'percy exec -- npx'
         wait-on: http://localhost:3000
       env: 
-        PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+        PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_E2E }}


### PR DESCRIPTION
We are using separate Percy projects for the e2e cypress test (currently a single screenshot), and the storybook components (one per story). This fix uses the correct Percy token for the cypress tests.