### PR TITLE
remove libcal api from public config for preview mode

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -10,13 +10,13 @@ export default {
     publicRuntimeConfig: {
         libcalAppointment: process.env.LIBCAL_APPOINTMENTS,
         libcalClientSecret:
-            process.env.LIVE_PREVIEW === true
+            process.env.LIVE_PREVIEW === "dev"
                 ? process.env.LIBCAL_CLIENT_SECRET
-                : "",
+                : "test",
         libcalClientId:
-            process.env.LIVE_PREVIEW === true
+            process.env.LIVE_PREVIEW === "dev"
                 ? process.env.LIBCAL_CLIENT_ID
-                : "", 
+                : "test", 
     },
 
     /*


### PR DESCRIPTION
This is a workaround for LibCal, Eventually, we do not want any libcal keys which are private in our nuxt app. In future work, we need to write a fetch token service which will be another app like middleware between Nuxt app and Libcal. 