### PR TITLE
fix: orcid id to appear on publications sections

### DIFF
--- a/components/BlockStaffDetail.vue
+++ b/components/BlockStaffDetail.vue
@@ -146,7 +146,6 @@ import SvgIconLocation from "~/node_modules/ucla-library-design-tokens/assets/sv
 import SvgIconEmail from "~/node_modules/ucla-library-design-tokens/assets/svgs/icon-email"
 import SvgIconPhone from "~/node_modules/ucla-library-design-tokens/assets/svgs/icon-phone"
 import SvgIconConsultation from "~/node_modules/ucla-library-design-tokens/assets/svgs/icon-chat"
-import SvgIconPerson from "~/node_modules/ucla-library-design-tokens/assets/svgs/icon-person"
 
 export default {
     components: {
@@ -155,7 +154,6 @@ export default {
         SvgIconEmail,
         SvgIconPhone,
         SvgIconConsultation,
-        SvgIconPerson,
     },
     props: {
         image: {
@@ -409,6 +407,9 @@ export default {
 
             .ask-me-about {
                 margin-bottom: var(--space-2xl);
+                ul {
+                    margin: 0;
+                }
             }
 
             .secondary-header {

--- a/components/SectionStaffOrcidPublications.vue
+++ b/components/SectionStaffOrcidPublications.vue
@@ -1,27 +1,27 @@
 <template lang="html">
-    <section class="section-staff-orcid-publications">
-        <divider-way-finder
-            class="divider divider-first"
-            color="about"
-        />
-        <div
-            v-if="sectionTitle"
-            class="section-title"
-            v-html="sectionTitle"
-        />
+    <section
+        v-if="orcid || publications"
+        class="section-staff-orcid-publications"
+    >
+        <h2 class="secondary-header">
+            Publications
+        </h2>
         <div
             v-if="orcid"
-            class="orcid"
-            v-html="orcid"
-        />
-        <div
+            class="orcid-key"
+        >
+            ORCID:
+            <smart-link
+                :to="orcid"
+                target="_blank"
+                class="orcid-value"
+                v-html="orcid"
+            />
+        </div>
+        <rich-text
             v-if="publications"
             class="publications"
-            v-html="publications"
-        />
-        <divider-way-finder
-            class="divider divider-first"
-            color="about"
+            :rich-text-content="publications"
         />
     </section>
 </template>
@@ -29,11 +29,6 @@
 <script>
 export default {
     props: {
-        sectionTitle: {
-            type: String,
-            default: "",
-            required: true,
-        },
         orcid: {
             type: String,
             default: "",
@@ -48,15 +43,31 @@ export default {
 
 <style lang="scss" scoped>
 .section-staff-orcid-publications {
-    max-width: 100%;
-    margin: auto;
+    max-width: $container-l-main + px;
+    margin: 0 auto;
 
-    .section-title {
+    .secondary-header {
+        margin-bottom: var(--space-l);
         @include step-3;
-        text-transform: capitalize;
         color: var(--color-primary-blue-03);
-        padding-top: 100px;
-        padding-bottom: 10px;
+    }
+
+    .orcid-key {
+        @include step-1;
+        color: var(--color-primary-blue-03);
+
+        .orcid-value {
+            @include step-0;
+            @include link-default;
+
+            &:hover {
+                @include link-hover;
+            }
+        }
+    }
+
+    .publications {
+        padding-right: 0;
     }
 
 
@@ -64,6 +75,11 @@ export default {
         .orcid-value:hover {
             @include link-hover;
         }
+    }
+
+    @media #{$medium} {
+        margin-left: var(--unit-gutter);
+        margin-right: var(--unit-gutter);
     }
 }
 </style>

--- a/pages/about/staff/_slug.vue
+++ b/pages/about/staff/_slug.vue
@@ -21,34 +21,17 @@
         />
 
         <section
-            v-if="parsedItems.length || page.entry.publications"
+            v-if="parsedItems.length || page.entry.publications || page.entry.orcid"
             class="selected-articles"
         >
-            <section
-                v-if="page.entry.orcid || page.entry.publications"
+            <section-staff-orcid-publications
                 class="staff-orcid-publications"
-            >
-                <h2 class="secondary-header">
-                    Publications
-                </h2>
-                <div class="orcid-key">
-                    ORCID:
-                    <smart-link
-                        :to="page.entry.orcid"
-                        target="_blank"
-                        class="orcid-value"
-                        v-html="`${page.entry.orcid}`"
-                    />
-                </div>
-                <rich-text
-                    v-if="page.entry.publications"
-                    class="publications"
-                    :rich-text-content="page.entry.publications"
-                />
-            </section>
+                :orcid="page.entry.orcid"
+                :publications="page.entry.publications"
+            />
 
             <divider-way-finder
-                v-if="parsedItems && page.entry.publications"
+                v-if="parsedItems.length && (page.entry.publications || page.entry.orcid)"
                 class="divider divider-first"
                 color="about"
             />
@@ -130,42 +113,6 @@ export default {
 
         ::v-deep .divider .dotted {
             border-color: var(--color-secondary-grey-03);
-        }
-    }
-
-    .staff-orcid-publications {
-        max-width: $container-l-main + px;
-        margin: 0 auto var(--space-3xl) auto;
-    }
-
-    .secondary-header {
-        margin-bottom: var(--space-l);
-        @include step-3;
-        color: var(--color-primary-blue-03);
-    }
-
-    .orcid-key {
-        @include step-1;
-        color: var(--color-primary-blue-03);
-
-        .orcid-value {
-            @include step-0;
-            @include link-default;
-
-            &:hover {
-                @include link-hover;
-            }
-        }
-    }
-
-    .publications {
-        padding-right: 0;
-    }
-
-    @media #{$medium} {
-        .staff-orcid-publications {
-            margin-left: var(--unit-gutter);
-            margin-right: var(--unit-gutter);
         }
     }
 }


### PR DESCRIPTION
- orcid id only appeared if the publications field had a value. this fixes the display so that orcid id appears regardless of the publications field. 
- refactors to correctly use  the SectionStaffOrcidPublications component
- removes SvgIconPerson from BlockStaffDetail since it wasn't being used