### PR TITLE
fix: update graphql queries and location detail page

### DIFF
--- a/components/BlockCampusMap.vue
+++ b/components/BlockCampusMap.vue
@@ -13,12 +13,12 @@
                 />
             </div>
         </modal-generic>
-        <h3
+        <button
             class="title"
             @click="showModal"
         >
             Campus Map
-        </h3>
+        </button>
         <div class="content">
             <div class="iframe-hover">
                 <div class="iframe-container">

--- a/components/Flexible/MediaWithText.vue
+++ b/components/Flexible/MediaWithText.vue
@@ -49,7 +49,6 @@ export default {
     computed: {
         parsedContent() {
             const mediaWithText = this.block.mediaWithText
-            console.log(mediaWithText)
             return mediaWithText.map((obj) => {
                 return {
                     ...obj,

--- a/components/SectionSpacesList.vue
+++ b/components/SectionSpacesList.vue
@@ -4,8 +4,8 @@
             Spaces
         </h3>
         <block-spaces
-            v-for="item in items"
-            :key="item.to"
+            v-for="(item, index) in items"
+            :key="`BlockSpace${index}`"
             :to="item.to"
             :title="item.title"
             :is-online="item.isOnline"

--- a/components/SectionSpacesList.vue
+++ b/components/SectionSpacesList.vue
@@ -1,5 +1,8 @@
 <template lang="html">
     <section class="section-spaces-list">
+        <h3 class="spaces-title">
+            Spaces
+        </h3>
         <block-spaces
             v-for="item in items"
             :key="item.to"
@@ -31,11 +34,16 @@ export default {
     display: flex;
     flex-direction: column;
     flex-wrap: nowrap;
-    justify-content: center;
+    justify-content: flex-start;
 
     max-width: 990px;
     margin: 0 auto;
 
+    .spaces-title {
+        color: var(--color-primary-blue-03);
+        @include step-2;
+        margin-bottom: 16px;
+    }
     .block {
         margin-bottom: var(--space-m);
     }

--- a/components/SectionTeaserCard.vue
+++ b/components/SectionTeaserCard.vue
@@ -1,8 +1,8 @@
 <template lang="html">
     <section class="section-teaser-card">
         <block-highlight
-            v-for="card in items"
-            :key="card.to"
+            v-for="(card, index) in items"
+            :key="`Card${index}`"
             class="card"
             :image="card.image"
             :to="card.to"

--- a/gql/queries/LocationDetail.gql
+++ b/gql/queries/LocationDetail.gql
@@ -135,6 +135,7 @@ query LocationDetail($slug: [String!]) {
             associatedLocations {
                 id
                 title
+                to: uri
             }
             requiresRegistration
             eventDescription

--- a/gql/queries/LocationDetail.gql
+++ b/gql/queries/LocationDetail.gql
@@ -149,7 +149,7 @@ query LocationDetail($slug: [String!]) {
             }
             eventType
             eventLocation
-            onlineEventUrl
+            isOnline: onlineEventUrl
             moreInformation
             eventOwner
         }

--- a/gql/queries/LocationDetail.gql
+++ b/gql/queries/LocationDetail.gql
@@ -26,7 +26,7 @@ query LocationDetail($slug: [String!]) {
             amenities(label: true)
             space {
                 title
-                summary
+                text: summary
                 reservationRequired
                 mediatorEmail
                 reservationUrl
@@ -73,6 +73,7 @@ query LocationDetail($slug: [String!]) {
         ... on article_article_Entry {
             id
             title
+            articleType
             associatedLocations {
                 id
                 title
@@ -95,7 +96,8 @@ query LocationDetail($slug: [String!]) {
             }
             description: summary
             category: typeHandle
-            date: dateUpdated
+            startDate: dateUpdated
+            endDate: dateUpdated
         }
     }
     associatedEndowments: entries(
@@ -104,7 +106,7 @@ query LocationDetail($slug: [String!]) {
     ) {
         ... on endowment_endowments_Entry {
             id
-            uri
+            slug
             title
             summary
             dateUpdated
@@ -118,41 +120,39 @@ query LocationDetail($slug: [String!]) {
             }
         }
     }
-    # associatedEvents: entries(
-    #     section: "event"
-    #     relatedToEntries: { section: "location", slug: $slug }
-    # ) {
-    #     ... on event_event_Entry {
-    #         id
-    #         title
-    #         id
-    #         uri
-    #         title
-    #         summary
-    #         dateUpdated
-    #         heroImage {
-    #             ... on heroImage_heroImage_BlockType {
-    #                 id
-    #                 image {
-    #                     ...Image
-    #                 }
-    #             }
-    #         }
-    #         date {
-    #             startDate
-    #             endDate
-    #         }
-    #         seriesDate {
-    #             startDate
-    #             endDate
-    #         }
-    #         associatedLocations {
-    #             id
-    #             title
-    #             to: uri
-    #         }
-    #     }
-    # }
+    associatedEvents: entries(
+        section: "event"
+        relatedToEntries: { section: "location", slug: $slug }
+    ) {
+        ... on event_event_Entry {
+            id
+            slug
+            title
+            date {
+                startTime
+                endTime
+            }
+            associatedLocations {
+                id
+                title
+            }
+            requiresRegistration
+            eventDescription
+            heroImage {
+                ... on heroImage_heroImage_BlockType {
+                    id
+                    image {
+                        ...Image
+                    }
+                }
+            }
+            eventType
+            eventLocation
+            onlineEventUrl
+            moreInformation
+            eventOwner
+        }
+    }
     associatedExhibitions: entries(
         section: "exhibition"
         relatedToEntries: { section: "location", slug: $slug }

--- a/gql/queries/LocationDetail.gql
+++ b/gql/queries/LocationDetail.gql
@@ -27,7 +27,7 @@ query LocationDetail($slug: [String!]) {
             space {
                 title
                 summary
-                mediatedBooking
+                reservationRequired
                 mediatorEmail
                 reservationUrl
                 spaceType {
@@ -60,78 +60,130 @@ query LocationDetail($slug: [String!]) {
                 email
                 to: uri
             }
-            exhibitsAndEvents(orderBy: "dateUpdated desc", limit: 3) {
+
+            ...FlexibleBlocksLocation
+        }
+    }
+    associatedArticles: entries(
+        section: "article"
+        relatedToEntries: { section: "location", slug: $slug }
+    ) {
+        ... on article_article_Entry {
+            id
+            title
+            associatedLocations {
                 id
-                uri
                 title
-                summary
-                dateUpdated
-                heroImage {
-                    ... on heroImage_heroImage_BlockType {
-                        id
-                        image {
-                            ...Image
-                        }
-                    }
-                }
-                date {
-                    startDate
-                    endDate
-                }
-                seriesDate {
-                    startDate
-                    endDate
-                }
-                associatedLocations {
+            }
+            to: slug
+            heroImage {
+                ... on heroImage_heroImage_BlockType {
                     id
-                    title
-                    to: uri
-                }
-            }
-            endowment(orderBy: "dateUpdated desc", limit: 3) {
-                id
-                uri
-                title
-                summary
-                dateUpdated
-                heroImage {
-                    ... on heroImage_heroImage_BlockType {
-                        id
-                        image {
-                            ...Image
-                        }
+                    image {
+                        ...Image
                     }
+                    altText
                 }
             }
-            associatedArticles(orderBy: "dateUpdated desc", limit: 3) {
+
+            authors: staffMember {
                 id
-                uri
                 slug
                 title
-                summary
-                articleType
-                author: staffMember {
+            }
+            description: summary
+            category: typeHandle
+            date: dateUpdated
+        }
+    }
+    associatedEndowments: entries(
+        section: "endowments"
+        relatedToEntries: { section: "location", slug: $slug }
+    ) {
+        ... on endowment_endowments_Entry {
+            id
+            uri
+            title
+            summary
+            dateUpdated
+            heroImage {
+                ... on heroImage_heroImage_BlockType {
                     id
-                    slug
-                    title
-                }
-                articleType
-                startDate: dateUpdated
-                endDate: dateUpdated
-                associatedLocations {
-                    id
-                    title
-                }
-                heroImage {
-                    ... on heroImage_heroImage_BlockType {
-                        id
-                        image {
-                            ...Image
-                        }
+                    image {
+                        ...Image
                     }
                 }
             }
-            ...FlexibleBlocksLocation
+        }
+    }
+    associatedEvents: entries(
+        section: "event"
+        relatedToEntries: { section: "location", slug: $slug }
+    ) {
+        ... on event_event_Entry {
+            id
+            title
+            id
+            uri
+            title
+            summary
+            dateUpdated
+            heroImage {
+                ... on heroImage_heroImage_BlockType {
+                    id
+                    image {
+                        ...Image
+                    }
+                }
+            }
+            date {
+                startDate
+                endDate
+            }
+            seriesDate {
+                startDate
+                endDate
+            }
+            associatedLocations {
+                id
+                title
+                to: uri
+            }
+        }
+    }
+    associatedExhibitions: entries(
+        section: "exhibition"
+        relatedToEntries: { section: "location", slug: $slug }
+    ) {
+        ... on exhibition_exhibition_Entry {
+            id
+            title
+            id
+            uri
+            title
+            summary
+            dateUpdated
+            heroImage {
+                ... on heroImage_heroImage_BlockType {
+                    id
+                    image {
+                        ...Image
+                    }
+                }
+            }
+            date {
+                startDate
+                endDate
+            }
+            seriesDate {
+                startDate
+                endDate
+            }
+            associatedLocations {
+                id
+                title
+                to: uri
+            }
         }
     }
 }

--- a/gql/queries/LocationDetail.gql
+++ b/gql/queries/LocationDetail.gql
@@ -67,6 +67,8 @@ query LocationDetail($slug: [String!]) {
     associatedArticles: entries(
         section: "article"
         relatedToEntries: { section: "location", slug: $slug }
+        orderBy: "dateUpdated desc"
+        limit: 3
     ) {
         ... on article_article_Entry {
             id
@@ -116,41 +118,41 @@ query LocationDetail($slug: [String!]) {
             }
         }
     }
-    associatedEvents: entries(
-        section: "event"
-        relatedToEntries: { section: "location", slug: $slug }
-    ) {
-        ... on event_event_Entry {
-            id
-            title
-            id
-            uri
-            title
-            summary
-            dateUpdated
-            heroImage {
-                ... on heroImage_heroImage_BlockType {
-                    id
-                    image {
-                        ...Image
-                    }
-                }
-            }
-            date {
-                startDate
-                endDate
-            }
-            seriesDate {
-                startDate
-                endDate
-            }
-            associatedLocations {
-                id
-                title
-                to: uri
-            }
-        }
-    }
+    # associatedEvents: entries(
+    #     section: "event"
+    #     relatedToEntries: { section: "location", slug: $slug }
+    # ) {
+    #     ... on event_event_Entry {
+    #         id
+    #         title
+    #         id
+    #         uri
+    #         title
+    #         summary
+    #         dateUpdated
+    #         heroImage {
+    #             ... on heroImage_heroImage_BlockType {
+    #                 id
+    #                 image {
+    #                     ...Image
+    #                 }
+    #             }
+    #         }
+    #         date {
+    #             startDate
+    #             endDate
+    #         }
+    #         seriesDate {
+    #             startDate
+    #             endDate
+    #         }
+    #         associatedLocations {
+    #             id
+    #             title
+    #             to: uri
+    #         }
+    #     }
+    # }
     associatedExhibitions: entries(
         section: "exhibition"
         relatedToEntries: { section: "location", slug: $slug }

--- a/gql/queries/ServiceOrResourceDetail.gql
+++ b/gql/queries/ServiceOrResourceDetail.gql
@@ -105,26 +105,26 @@ fragment BlockMediaGallery on defaultFpbWithNoCta_mediaGallery_BlockType {
 }
 
 fragment BlockSimpleCards on defaultFpbWithNoCta_simpleCards_BlockType {
-  id
-  sectionTitle: titleGeneral
-  sectionSummary: summary
-  cards: simpleCards {
-    ... on simpleCards_internalServiceOrResource_BlockType {
-        id
-        title: titleGeneral
-        summary
-        contentLink {
-            slug
-            title
+    id
+    sectionTitle: titleGeneral
+    sectionSummary: summary
+    cards: simpleCards {
+        ... on simpleCards_internalServiceOrResource_BlockType {
+            id
+            title: titleGeneral
             summary
-            researchGuideUrl
+            contentLink {
+                slug
+                title
+                summary
+                researchGuideUrl
+            }
         }
-    }
-    ... on simpleCards_externalServiceOrResource_BlockType {
-        id
-        title: titleGeneral
-        summary
-        externalLink
+        ... on simpleCards_externalServiceOrResource_BlockType {
+            id
+            title: titleGeneral
+            summary
+            externalLink
         }
     }
 }

--- a/pages/visit/locations/_slug.vue
+++ b/pages/visit/locations/_slug.vue
@@ -102,7 +102,7 @@
             </nuxt-link>
         </div>
         <divider-way-finder
-            v-if="parsedExhibtions.length"
+            v-if="mergeSortEventsExhibitions.length"
             color="visit"
             class="divider-way-finder"
         />

--- a/pages/visit/locations/_slug.vue
+++ b/pages/visit/locations/_slug.vue
@@ -265,6 +265,7 @@ export default {
                     text: _get(obj, "eventDescription", ""),
                     startDate: _get(obj, "date[0].startTime", ""),
                     endDate: _get(obj, "date[0].endTime", ""),
+                    locations: _get(obj, "associatedLocations", []),
                 }
             })
         },

--- a/pages/visit/locations/_slug.vue
+++ b/pages/visit/locations/_slug.vue
@@ -220,11 +220,11 @@ export default {
                 return {
                     ...obj,
                     buttonText:
-                        obj.mediatedBooking === "yes"
+                        obj.reservationRequired === "email"
                             ? obj.mediatorEmail
                             : "Reserve",
                     to:
-                        obj.mediatedBooking === "yes"
+                        obj.reservationRequired === "email"
                             ? `mailto:${obj.mediatorEmail}`
                             : obj.reservationUrl,
                     location: obj.associatedLocations

--- a/pages/visit/locations/_slug.vue
+++ b/pages/visit/locations/_slug.vue
@@ -54,24 +54,11 @@
             v-if="parsedSpaces.length"
             class="divider-general"
         />
-        <div
+        <section-spaces-list
             v-if="parsedSpaces.length"
             class="section-block-spaces"
-        >
-            <h3 class="spaces-title">
-                {{ page.title }} Spaces
-            </h3>
-
-            <block-spaces
-                v-for="(space, index) in parsedSpaces"
-                :key="index"
-                :title="space.title"
-                :text="space.summary"
-                :to="space.to"
-                :button-text="space.buttonText"
-            />
-        </div>
-
+            :items="parsedSpaces"
+        />
         <divider-way-finder
             v-if="page.resourceServiceWorkshop.length"
             color="visit"
@@ -315,13 +302,6 @@ export default {
     }
     .section-teaser-list {
         margin: var(--space-xl) auto;
-    }
-    .spaces-title {
-        @include step-2;
-        color: var(--color-primary-blue-03);
-        margin: var(--space-2xl) auto 16px;
-        max-width: $container-l-main + px;
-        // margin-bottom: 16px;
     }
 
     .block-hours,

--- a/pages/visit/locations/_slug.vue
+++ b/pages/visit/locations/_slug.vue
@@ -50,7 +50,7 @@
             :location-name="page.title"
             :building-access="page.howToGetHere"
         />
-        <divider-general
+        <!-- <divider-general
             v-if="parsedSpaces.length"
             class="divider-general"
         />
@@ -58,7 +58,7 @@
             v-if="parsedSpaces.length"
             class="section-block-spaces"
             :items="parsedSpaces"
-        />
+        /> -->
         <divider-way-finder
             v-if="page.resourceServiceWorkshop.length"
             color="visit"
@@ -83,7 +83,7 @@
             class="divider-way-finder"
         />
         <div
-            v-if="parsedEvents.length"
+            v-if="parsedExhibtions.length"
             class="events-exhibitions"
         >
             <h2 class="section-heading">
@@ -91,10 +91,10 @@
             </h2>
             <section-teaser-list
                 class="section-teaser-list"
-                :items="parsedEvents"
+                :items="parsedExhibtions"
             />
             <nuxt-link
-                v-if="parsedEvents.length"
+                v-if="parsedExhibtions.length"
                 class="button-more"
                 to="/visit/events-exhibits"
             >
@@ -102,7 +102,7 @@
             </nuxt-link>
         </div>
         <divider-way-finder
-            v-if="parsedEvents.length"
+            v-if="parsedExhibtions.length"
             color="visit"
             class="divider-way-finder"
         />
@@ -164,8 +164,12 @@ export default {
         const data = await $graphql.default.request(LOCATION_DETAIL, {
             slug: params.slug,
         })
+        console.log(data)
         return {
             page: _get(data, "entry", {}),
+            associatedArticles: _get(data, "associatedArticles", {}),
+            associatedExhibitions: _get(data, "associatedExhibitions", {}),
+            associatedEndowments: _get(data, "associatedEndowments", {}),
         }
     },
     head() {
@@ -239,8 +243,8 @@ export default {
                 }
             })
         },
-        parsedEvents() {
-            return this.page.associatedExhibitions.map((obj) => {
+        parsedExhibtions() {
+            return this.associatedExhibitions.map((obj) => {
                 return {
                     ...obj,
                     to: `/events-exhibtions/${obj.id}`,
@@ -253,7 +257,7 @@ export default {
             })
         },
         parsedEndowments() {
-            return this.page.associatedEndowments.map((obj) => {
+            return this.associatedEndowments.map((obj) => {
                 return {
                     ...obj,
                     to: `/${obj.uri}`,
@@ -263,7 +267,7 @@ export default {
             })
         },
         parsedArticles() {
-            return this.page.associatedArticles.map((obj) => {
+            return this.associatedArticles.map((obj) => {
                 return {
                     ...obj,
                     to: `/${obj.uri}`,

--- a/pages/visit/locations/_slug.vue
+++ b/pages/visit/locations/_slug.vue
@@ -253,7 +253,7 @@ export default {
             })
         },
         parsedEvents() {
-            return this.page.exhibitsAndEvents.map((obj) => {
+            return this.page.associatedExhibitions.map((obj) => {
                 return {
                     ...obj,
                     to: `/events-exhibtions/${obj.id}`,
@@ -266,7 +266,7 @@ export default {
             })
         },
         parsedEndowments() {
-            return this.page.endowment.map((obj) => {
+            return this.page.associatedEndowments.map((obj) => {
                 return {
                     ...obj,
                     to: `/${obj.uri}`,


### PR DESCRIPTION
Connected to [APPS-1572](https://jira.library.ucla.edu/browse/APPS-1572) and [APPS-1573](https://jira.library.ucla.edu/browse/APPS-1573)

[APPS-1572](https://jira.library.ucla.edu/browse/APPS-1572)
- Remove Spaces title from page template locations/_slug.vue
- Hard code "Spaces" as title of BlockSpaces component (no longer including library location name, matching BlockHours and BlockCampusMap)
- Remove location link

[APPS-1573](https://jira.library.ucla.edu/browse/APPS-1573)
- Fix graphql for Craft updates