### PR TITLE
fix: update blockspaces to use richtext

### DIFF
--- a/components/BlockSpaces.vue
+++ b/components/BlockSpaces.vue
@@ -20,9 +20,9 @@
                 />
             </div>
             <div class="meta">
-                <p
+                <rich-text
                     class="text"
-                    v-html="text"
+                    :rich-text-content="text"
                 />
                 <!-- if no buttonUrl -  do not display button -->
                 <button-link


### PR DESCRIPTION
Connected to [APPS-1596](https://jira.library.ucla.edu/browse/APPS-1596)

Update BlockSpaces to use `richtext` component for summary so that links are styled.
<img width="1053" alt="Screen Shot 2022-06-22 at 10 25 40 AM" src="https://user-images.githubusercontent.com/34147754/175099902-e7ee6a4d-9137-48d6-82c4-f14028c9f9ff.png">

