### PR TITLE
fix: update simple card spacing

### DIFF
--- a/components/SimpleCards.vue
+++ b/components/SimpleCards.vue
@@ -80,10 +80,10 @@ export default {
     .section-title {
         @include step-4;
         color: var(--color-primary-blue-03);
-        margin-bottom: var(--space-m);
     }
     .section-summary {
         @include step-0;
+        margin-top: var(--space-m);
 
         ::v-deep p {
             margin: 0;


### PR DESCRIPTION
Connected to [APPS-1606](https://jira.library.ucla.edu/browse/APPS-1606)

- [x] if there is no .section-summary, then remove margin-bottom from .section-title, so that total margin below .section-header is var(--space-xl)
<img width="1440" alt="Screen Shot 2022-06-22 at 12 26 23 PM" src="https://user-images.githubusercontent.com/34147754/175120795-5fcb1f5b-4a90-4941-9b8c-2c42e0a28af6.png">

