### PR TITLE
chore: Add Github labels that release-drafter will use to decode the version number

### DIFF
--- a/.github/configs/release-drafter.yml
+++ b/.github/configs/release-drafter.yml
@@ -1,31 +1,53 @@
-name-template: 'v$RESOLVED_VERSION 🌈'
-tag-template: 'v$RESOLVED_VERSION'
+
 categories:
-  - title: '🚀 Features'
+  - title: '🚀 Features and Improvements'
     labels:
       - 'feature'
       - 'enhancement'
+      - 'performance'
+  - title: '🌈 Chore Updates'
+    labels:
+      - 'documentation'
+      - 'chore'
+      - 'test'
+      - 'ci'
   - title: '🐛 Bug Fixes'
     labels:
-      - 'fix'
       - 'bugfix'
-      - 'bug'
-  - title: '🧰 Maintenance'
-    label: 'chore'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+      - 'fix'
+  - title: '🧰 Breaking Changes'
+    label: 'breaking'
 version-resolver:
   major:
     labels:
-      - 'major'
+      - 'breaking'
   minor:
     labels:
-      - 'minor'
+      - 'enhancement'
+      - 'feature'
+      - 'performance'
+      - 'refactor'
   patch:
     labels:
-      - 'patch'
+      - 'bugfix'
+      - 'documentation'
+      - 'fix'
+      - 'chore'
+      - 'test'
+      - 'ci'
+
   default: patch
+tag-template: '$RESOLVED_VERSION'
+name-template: 'v$RESOLVED_VERSION'
+change-template: '* $TITLE (#$NUMBER)'
+change-title-escapes: ''
+exclude-labels:
+  - 'skip-changelog'
 template: |
-  ## Changes
+  ## What’s Changed
 
   $CHANGES
+
+  ## Contributors
+
+  $CONTRIBUTORS


### PR DESCRIPTION
Going forward, Before we merge the PR's we need to add following Github labels:

- breaking - A change that breaks backwards compatibility (this represents a major version bump)

 A change that fixes something in a backwards compatible way (this represents a patch version bump)

- bugfix 
- fix
- chore
- documentation
- ci

An improvement to an existing feature (this represents a minor version bump)

- enhancement
- feature
- refactor
