### PR TITLE
ci: On merge to main github-deployment-environment is set to test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,12 +114,12 @@ jobs:
       if: github.ref_name=='main'
       uses: nwtgck/actions-netlify@b7c1504e00c6b8a249d1848cc1b522a4865eed99 # v1.2.3
       with:
-        production-deploy: true
+        production-deploy: false
         deploy-message: https://github.com/UCLALibrary/library-website-nuxt/commit/${{ github.sha }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
         publish-dir: './dist'
         fails-without-credentials: true
-        github-deployment-environment: production
+        github-deployment-environment: test
       env:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}


### PR DESCRIPTION
Right now we have following
![image](https://user-images.githubusercontent.com/4259468/175629275-5d51ee1e-2be1-4cad-ab37-1bf106f65a59.png)

and this PR will add `test` to the list.