### PR TITLE
fix: APPS-1653 Update Location template

### DIFF
--- a/components/BannerFeatured.vue
+++ b/components/BannerFeatured.vue
@@ -58,10 +58,10 @@
                 /-->
             </h3>
 
-            <p
+            <rich-text
                 v-if="description"
                 class="description"
-                v-html="description"
+                :rich-text-content="description"
             />
 
             <div

--- a/components/BannerHeader.vue
+++ b/components/BannerHeader.vue
@@ -37,10 +37,10 @@
                 class="title"
                 v-html="title"
             />
-            <div
+            <rich-text
                 v-if="text"
                 class="snippet"
-                v-html="text"
+                :rich-text-content="text"
             />
             <div class="byline">
                 <div
@@ -108,7 +108,7 @@
                     :is="`svg-icon-person`"
                     class="contact-svg"
                 />
-                <nuxt-link
+                <smart-link
                     :to="staffDirectoryLink"
                     class="link-icon"
                     v-html="`View staff directory`"

--- a/components/BannerText.vue
+++ b/components/BannerText.vue
@@ -16,10 +16,10 @@
                     class="title"
                     v-html="title"
                 />
-                <div
+                <rich-text
                     v-if="text"
                     class="text"
-                    v-html="text"
+                    :rich-text-content="text"
                 />
                 <div
                     v-if="date"

--- a/components/BlockCampusMap.vue
+++ b/components/BlockCampusMap.vue
@@ -16,9 +16,7 @@
         <button
             class="title"
             @click="showModal"
-        >
-            Campus Map
-        </button>
+        />
         <div class="content">
             <div class="iframe-hover">
                 <div class="iframe-container">
@@ -92,11 +90,6 @@ export default {
     margin: 0 auto;
     position: relative;
 
-    .title {
-        color: var(--color-primary-blue-03);
-        @include step-2;
-        margin-bottom: 16px;
-    }
     .title::after {
         content: "";
         position: absolute;

--- a/components/BlockSpaces.vue
+++ b/components/BlockSpaces.vue
@@ -137,6 +137,9 @@ export default {
                     line-height: 20px;
                 }
             }
+            ::v-deep .rich-text {
+                margin: 0;
+            }
             .text {
                 @include step-0;
                 margin-top: 0;

--- a/pages/about/news/_slug.vue
+++ b/pages/about/news/_slug.vue
@@ -1,21 +1,8 @@
-// articleType - nowhere
-// summary - nowhere
-// associatedLocations - nowhere
-// department - nowhere
-
-// title
-// heroImage banner Image
-// articleCategories (library news)
-// staffMember
-
-// allFpb
-// bannerheader
-// date published
-
-// TODO
-// fix: ServiceOrResources
-// add: share links & icons component
-// fix: author
+// articleType - nowhere // summary - nowhere // associatedLocations - nowhere
+// department - nowhere // title // heroImage banner Image // articleCategories
+(library news) // staffMember // allFpb // bannerheader // date published //
+TODO // fix: ServiceOrResources // add: share links & icons component // fix:
+author
 
 <template lang="html">
     <section class="page-news-detail">
@@ -72,12 +59,9 @@ export default {
         console.log(
             "fetching graphql data for Service or Resource detail from Craft for live preview"
         )
-        const data = await $graphql.default.request(
-            ARTICLE_NEWS_DETAIL,
-            {
-                slug: params.slug,
-            }
-        )
+        const data = await $graphql.default.request(ARTICLE_NEWS_DETAIL, {
+            slug: params.slug,
+        })
         console.log("Data fetched: " + JSON.stringify(data))
         return {
             page: _get(data, "entry", {}),
@@ -93,12 +77,12 @@ export default {
         parsedBylines() {
             let bylines = this.page.byline.map((name) => {
                 return {
-                    fullName: `${name.nameFirst} ${name.nameLast}`
+                    fullName: `${name.nameFirst} ${name.nameLast}`,
                 }
             })
 
-            return bylines.map(({fullName})=>{ 
-                return (`${fullName}`)
+            return bylines.map(({ fullName }) => {
+                return `${fullName}`
             })
         },
 
@@ -123,13 +107,12 @@ export default {
         //             linkedLocation: `<a href="${place.uri}">${place.title}</a>`
         //         }
         //     })
-        //     return places.map(({linkedLocation})=>{ 
+        //     return places.map(({linkedLocation})=>{
         //         return (`${linkedLocation}`)
         //     })
         // }
-    }
+    },
 }
-
 </script>
 
 <style lang="scss" scoped>

--- a/pages/visit/locations/_slug.vue
+++ b/pages/visit/locations/_slug.vue
@@ -43,13 +43,6 @@
             :items="page.amenities"
             class="amenities"
         />
-        <divider-general class="divider-general" />
-        <block-campus-map
-            v-if="page.campusMapId"
-            :campus-location-id="page.campusMapId"
-            :location-name="page.title"
-            :building-access="page.howToGetHere"
-        />
         <divider-general
             v-if="parsedSpaces.length"
             class="divider-general"
@@ -114,7 +107,7 @@
             class="content"
             :blocks="page.blocks"
         />
-        <h2
+        <!-- <h2
             v-if="parsedEndowments.length"
             class="section-heading"
         >
@@ -131,7 +124,7 @@
             to="/about/endowments"
         >
             <button-more text="See More" />
-        </nuxt-link>
+        </nuxt-link> -->
         <h2
             v-if="page.about"
             class="section-heading"
@@ -142,27 +135,23 @@
             class="about-text"
             :rich-text-content="page.about"
         />
+        <divider-way-finder
+            color="visit"
+            class="divider-way-finder"
+        />
         <h2
-            v-if="parsedArticles.length"
+            v-if="page.about"
             class="section-heading"
         >
-            News
+            Location & Access
         </h2>
-
-        <section-teaser-card
-            v-if="parsedArticles.length"
-            :items="parsedArticles"
-            class="articles"
-            to="/about/news"
+        <block-campus-map
+            v-if="page.campusMapId"
+            :campus-location-id="page.campusMapId"
+            :location-name="page.title"
+            :building-access="page.howToGetHere"
+            class="campus-map"
         />
-
-        <nuxt-link
-            v-if="parsedArticles.length"
-            class="button-more"
-            to="/about/news"
-        >
-            <button-more text="See More" />
-        </nuxt-link>
     </div>
 </template>
 
@@ -295,29 +284,6 @@ export default {
                             : 0
                 )
         },
-        parsedEndowments() {
-            console.log(this.mergeSortEventsExhibitions)
-            return this.associatedEndowments.map((obj) => {
-                return {
-                    ...obj,
-                    to: `/${obj.uri}`,
-                    image: _get(obj, "heroImage[0].image[0]", {}),
-                    text: obj.summary,
-                }
-            })
-        },
-        parsedArticles() {
-            return this.associatedArticles.map((obj) => {
-                return {
-                    ...obj,
-                    to: `/${obj.uri}`,
-                    image: _get(obj, "heroImage[0].image[0]", {}),
-                    text: obj.description,
-                    category: obj.articleType,
-                    author: _get(obj, "author[0].title", ""),
-                }
-            })
-        },
     },
 }
 </script>
@@ -356,38 +322,13 @@ export default {
         margin: var(--space-2xl) auto;
     }
 
-    .block-spaces,
-    .endowments,
-    .articles {
+    .block-spaces {
         margin: 16px auto;
     }
 
-    .endowment-group {
-        max-width: $container-l-main + px;
-        padding: 0 calc(var(--unit-gutter) - 16px);
-        background-color: var(--color-white);
-        margin: 0 auto;
-
-        display: flex;
-        flex-direction: row;
-        flex-wrap: wrap;
-        justify-content: flex-start;
-        align-content: flex-start;
-        align-items: flex-start;
+    .campus-map {
+        margin-bottom: var(--space-2xl);
     }
-
-    // .about-text {
-    //     @include step-0;
-    //     max-width: $container-l-text + px;
-    //     margin: var(--space-l) auto;
-    //
-    //     ::v-deep p {
-    //         font-family: var(--font-primary);
-    //         color: var(--color-black);
-    //         @include step-0;
-    //         margin: var(--space-l) 0;
-    //     }
-    // }
 
     // ::v-deep .flexible-block:last-child:not(.flexible-simple-cards) {
     //     background: red;

--- a/pages/visit/locations/_slug.vue
+++ b/pages/visit/locations/_slug.vue
@@ -107,24 +107,6 @@
             class="content"
             :blocks="page.blocks"
         />
-        <!-- <h2
-            v-if="parsedEndowments.length"
-            class="section-heading"
-        >
-            Endowments
-        </h2>
-
-        <section-teaser-card
-            :items="parsedEndowments"
-            class="endowments"
-        />
-        <nuxt-link
-            v-if="parsedEndowments.length"
-            class="button-more"
-            to="/about/endowments"
-        >
-            <button-more text="See More" />
-        </nuxt-link> -->
         <h2
             v-if="page.about"
             class="section-heading"

--- a/pages/visit/locations/_slug.vue
+++ b/pages/visit/locations/_slug.vue
@@ -137,7 +137,7 @@
             v-if="page.campusMapId"
             class="section-heading"
         >
-            Location & Access
+            Location &amp; Access
         </h2>
         <block-campus-map
             v-if="page.campusMapId"

--- a/pages/visit/locations/_slug.vue
+++ b/pages/visit/locations/_slug.vue
@@ -24,10 +24,22 @@
             :address-link="addressLink"
         />
         <divider-way-finder
+            v-if="
+                page.libcalLocationIdForHours ||
+                    page.amenities.length ||
+                    parsedSpaces.length
+            "
             color="visit"
             class="divider-way-finder"
         />
-        <h2 class="section-heading">
+        <h2
+            v-if="
+                page.libcalLocationIdForHours ||
+                    page.amenities.length ||
+                    parsedSpaces.length
+            "
+            class="section-heading"
+        >
             Using the Library
         </h2>
         <block-hours

--- a/pages/visit/locations/_slug.vue
+++ b/pages/visit/locations/_slug.vue
@@ -122,7 +122,7 @@
             class="divider-way-finder"
         />
         <h2
-            v-if="page.about"
+            v-if="page.campusMapId"
             class="section-heading"
         >
             Location & Access


### PR DESCRIPTION
Connected to [APPS-1653](https://jira.library.ucla.edu/browse/APPS-1653)

- [x] Sections should be in the following order, as seen on [updated Location page comp](https://www.figma.com/file/BLO5HP8AphPr0KEacFPjs8/COPY-of-UI-Pattern-Library-(Client-Facing)-Final?node-id=7169%3A52977):
              Using the Library
              Remove block-campus-map and divider-general
              Services & Resources
              Flexible Page Blocks
              Events & Exhibitions
              (remove Endowments)
              About
              Location & Access 
- [x] Text in banner-header and banner-text coming from Summary field in Location detail entries should include rich-text link styling
