### PR TITLE
feat: adds same error page layout used on meap site

### DIFF
--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -1,24 +1,34 @@
 <template>
-    <div class="text-center">
+    <main
+        id="main"
+        class="page page-error"
+    >
         <p class="error">
             404
         </p>
-        <h1
-            v-if="error.statusCode === 404"
-            class="mb-8"
-        >
-            Page not found
-        </h1>
-        <h1
-            v-else
-            class="mb-8"
-        >
-            An error occurred
-        </h1>
-        <nuxt-link to="/">
-            Go back to home page
-        </nuxt-link>
-    </div>
+        <divider-way-finder />
+
+        <rich-text class="error-text">
+            <h1
+                v-if="error.statusCode === 404"
+                class="error-title"
+            >
+                Page not found
+            </h1>
+            <h1
+                v-else
+                class="error-title"
+            >
+                An error occurred
+            </h1>
+            <p>We can’t find the page you are looking for, but we're here to help. <nuxt-link to="/">Go back to home page</nuxt-link> or try these regularly visited links:</p>
+            <ul>
+                <li><a href="https://library.ucla.edu">UCLA Library Home</a></li>
+                <li><a href="https://www.library.ucla.edu/research-teaching-support/research-help">Research Help</a></li>
+                <li><a href="https://www.library.ucla.edu/use/access-privileges/disability-resources">Accessibility Resources</a></li>
+            </ul>
+        </rich-text>
+    </main>
 </template>
 <script>
 export default {
@@ -30,8 +40,34 @@ export default {
     },
 }
 </script>
-<style scoped>
-.error {
-    font-size: 120px;
+<style lang="scss" scoped>
+.page-error {
+    padding: var(--space-3xl) var(--unit-gutter);
+
+    .error {
+        font-family: var(--font-secondary);
+        font-size: 248px;
+        font-weight: 600;
+        line-height: 1;
+        background: linear-gradient(20deg, #FD9BE0 10.99%, #E29AEE 23.02%, #C099FF 32.91%, #8BA0EF 42.44%, #0AA5FF 56.68%, #06BEF2 73.09%, #00E0E0 89.01%);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        background-clip: text;
+        text-fill-color: transparent;
+        text-align: center;
+    }
+    .error-title {
+        @include step-5;
+        margin-bottom: 32px;
+
+        p {
+            margin-bottom: var(--space-xl);
+        }
+    }
+    @media #{$small} {
+        .error {
+            font-size: 128px;
+        }
+    }
 }
 </style>


### PR DESCRIPTION
- copy and paste error layout used on meap site
- discovered an issue that the error pages do not render. getting the general content page template instead ([APPS-1953](https://jira.library.ucla.edu/browse/APPS-1953))