### PR TITLE
fix: update banners on impact pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
                 "sass": "^1.45.2",
                 "sass-loader": "^10.1.1",
                 "ucla-library-design-tokens": "^5.4.1",
-                "ucla-library-website-components": "^1.63.0",
+                "ucla-library-website-components": "^1.64.1",
                 "vue-svg-loader": "^0.16.0",
                 "vue-template-compiler": "^2.6.12"
             },
@@ -14947,9 +14947,9 @@
             "dev": true
         },
         "node_modules/ucla-library-website-components": {
-            "version": "1.63.0",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.63.0.tgz",
-            "integrity": "sha512-RI59RpbTuWRZ5RuC/bG9BHjl+Yx1y9E6++A2ntt5XCGbLcPCBJhaAZswWy91W17w3XDerqDbANiBzN5EhoqbMw==",
+            "version": "1.64.1",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.64.1.tgz",
+            "integrity": "sha512-EaH1pk7izecDMtOtchwR90DQF5OFFQAm6CtvLvlvZd869A6oZeyjxHKy2qpzKUp+qlHlaxWKclop28kFXUWCxg==",
             "dev": true,
             "dependencies": {
                 "date-fns": "^2.28.0",
@@ -28627,9 +28627,9 @@
             "dev": true
         },
         "ucla-library-website-components": {
-            "version": "1.63.0",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.63.0.tgz",
-            "integrity": "sha512-RI59RpbTuWRZ5RuC/bG9BHjl+Yx1y9E6++A2ntt5XCGbLcPCBJhaAZswWy91W17w3XDerqDbANiBzN5EhoqbMw==",
+            "version": "1.64.1",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.64.1.tgz",
+            "integrity": "sha512-EaH1pk7izecDMtOtchwR90DQF5OFFQAm6CtvLvlvZd869A6oZeyjxHKy2qpzKUp+qlHlaxWKclop28kFXUWCxg==",
             "dev": true,
             "requires": {
                 "date-fns": "^2.28.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
                 "sass": "^1.45.2",
                 "sass-loader": "^10.1.1",
                 "ucla-library-design-tokens": "^5.4.1",
-                "ucla-library-website-components": "^1.64.1",
+                "ucla-library-website-components": "^1.64.2",
                 "vue-svg-loader": "^0.16.0",
                 "vue-template-compiler": "^2.6.12"
             },
@@ -14947,9 +14947,9 @@
             "dev": true
         },
         "node_modules/ucla-library-website-components": {
-            "version": "1.64.1",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.64.1.tgz",
-            "integrity": "sha512-EaH1pk7izecDMtOtchwR90DQF5OFFQAm6CtvLvlvZd869A6oZeyjxHKy2qpzKUp+qlHlaxWKclop28kFXUWCxg==",
+            "version": "1.64.2",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.64.2.tgz",
+            "integrity": "sha512-yK3qQ9EohPBIS0Q2Tsns7aQdx+ye+Qxq3wPN2Rkgy+zdbSGzO1sJwV9BOnXWyBiMOHtnpMgXjCwDHb8v2jcwjg==",
             "dev": true,
             "dependencies": {
                 "date-fns": "^2.28.0",
@@ -28627,9 +28627,9 @@
             "dev": true
         },
         "ucla-library-website-components": {
-            "version": "1.64.1",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.64.1.tgz",
-            "integrity": "sha512-EaH1pk7izecDMtOtchwR90DQF5OFFQAm6CtvLvlvZd869A6oZeyjxHKy2qpzKUp+qlHlaxWKclop28kFXUWCxg==",
+            "version": "1.64.2",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.64.2.tgz",
+            "integrity": "sha512-yK3qQ9EohPBIS0Q2Tsns7aQdx+ye+Qxq3wPN2Rkgy+zdbSGzO1sJwV9BOnXWyBiMOHtnpMgXjCwDHb8v2jcwjg==",
             "dev": true,
             "requires": {
                 "date-fns": "^2.28.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "sass": "^1.45.2",
         "sass-loader": "^10.1.1",
         "ucla-library-design-tokens": "^5.4.1",
-        "ucla-library-website-components": "^1.63.0",
+        "ucla-library-website-components": "^1.64.1",
         "vue-svg-loader": "^0.16.0",
         "vue-template-compiler": "^2.6.12"
     }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "sass": "^1.45.2",
         "sass-loader": "^10.1.1",
         "ucla-library-design-tokens": "^5.4.1",
-        "ucla-library-website-components": "^1.64.1",
+        "ucla-library-website-components": "^1.64.2",
         "vue-svg-loader": "^0.16.0",
         "vue-template-compiler": "^2.6.12"
     }

--- a/pages/impact/_year/_slug.vue
+++ b/pages/impact/_year/_slug.vue
@@ -1,10 +1,7 @@
 <template lang="html">
     <main class="page page-impact-report">
         <banner-text
-            v-if="
-                (page && (!page.heroImage || page.heroImage.length == 0)) ||
-                    !isVideo
-            "
+            v-if="page && (!page.heroImage || page.heroImage.length == 0)"
             class="banner-text"
             :title="page.title"
             :text="page.text"
@@ -16,6 +13,7 @@
             class="section-banner"
         >
             <banner-featured
+                v-if="page && page.heroImage && page.heroImage.length == 1"
                 :image="page.heroImage[0].image[0]"
                 :ratio="40"
                 :title="page.title"
@@ -67,11 +65,9 @@ export default {
         parsedByline() {
             let bannerFeaturedByline = this.page.contributors.map((obj) => {
                 if (obj.typeHandle === "externalContributor") {
-                    return { title: `${obj.byline + " " + obj.title}` }
+                    return `${obj.byline + " " + obj.title}`
                 } else if (obj.typeHandle === "staffMember") {
-                    return {
-                        title: `${obj.byline + " " + obj.staffMember[0].title}`,
-                    }
+                    return `${obj.byline + " " + obj.staffMember[0].title}`
                 } else {
                     return []
                 }

--- a/pages/impact/_year/_slug.vue
+++ b/pages/impact/_year/_slug.vue
@@ -86,11 +86,6 @@ export default {
     //     margin-top: 0;
     //     margin-bottom: 0;
     // }
-    .banner-featured {
-        ::v-deep {
-            --banner-color-theme: var(--color-about-purple-03);
-        }
-    }
     // .banner-header {
     //     // margin-bottom: var(--space-xl);
     //     padding: 0;

--- a/pages/impact/_year/_slug.vue
+++ b/pages/impact/_year/_slug.vue
@@ -63,9 +63,11 @@ export default {
         parsedByline() {
             let bannerFeaturedByline = this.page.contributors.map((obj) => {
                 if (obj.typeHandle === "externalContributor") {
-                    return `${obj.byline + " " + obj.title}`
+                    return { title: `${obj.byline + " " + obj.title}` }
                 } else if (obj.typeHandle === "staffMember") {
-                    return `${obj.byline + " " + obj.staffMember[0].title}`
+                    return {
+                        title: `${obj.byline + " " + obj.staffMember[0].title}`,
+                    }
                 } else {
                     return []
                 }

--- a/pages/impact/_year/_slug.vue
+++ b/pages/impact/_year/_slug.vue
@@ -14,6 +14,7 @@
         >
             <banner-featured
                 v-if="page && page.heroImage && page.heroImage.length == 1"
+                class="banner-featured"
                 :image="page.heroImage[0].image[0]"
                 :ratio="40"
                 :title="page.title"
@@ -88,6 +89,11 @@ export default {
     //     margin-top: 0;
     //     margin-bottom: 0;
     // }
+    .banner-featured {
+        ::v-deep {
+            --banner-color-theme: var(--color-about-purple-03);
+        }
+    }
     // .banner-header {
     //     // margin-bottom: var(--space-xl);
     //     padding: 0;

--- a/pages/impact/_year/_slug.vue
+++ b/pages/impact/_year/_slug.vue
@@ -12,14 +12,11 @@
             v-if="page && page.heroImage && page.heroImage.length == 1"
             class="section-banner"
         >
-            <banner-featured
-                v-if="page && page.heroImage && page.heroImage.length == 1"
-                class="banner-featured"
-                :image="page.heroImage[0].image[0]"
-                :ratio="40"
+            <banner-header
                 :title="page.title"
-                :description="page.text"
+                :text="page.text"
                 :align-right="true"
+                :image="page.heroImage[0].image[0]"
                 :byline="parsedByline"
             />
         </section-wrapper>

--- a/pages/impact/_year/_slug.vue
+++ b/pages/impact/_year/_slug.vue
@@ -1,7 +1,10 @@
 <template lang="html">
     <main class="page page-impact-report">
         <banner-text
-            v-if="page && (!page.heroImage || page.heroImage.length == 0) || !isVideo"
+            v-if="
+                (page && (!page.heroImage || page.heroImage.length == 0)) ||
+                    !isVideo
+            "
             class="banner-text"
             :title="page.title"
             :text="page.text"
@@ -9,14 +12,15 @@
         />
 
         <section-wrapper
-            v-if="page && page.heroImage && page.heroImage.length == 1 || isVideo"
+            v-if="page && page.heroImage && page.heroImage.length == 1"
             class="section-banner"
         >
-            <banner-header
+            <banner-featured
+                :image="page.heroImage[0].image[0]"
+                :ratio="40"
                 :title="page.title"
-                :text="page.text"
+                :description="page.text"
                 :align-right="true"
-                :video="parsedVideo"
                 :byline="parsedByline"
             />
         </section-wrapper>
@@ -60,40 +64,6 @@ export default {
         }
     },
     computed: {
-        isVideo() {
-            if (!this.page.heroImage) return false
-            let fileName = this.page.heroImage[0].image[0].src.toLowerCase()
-            let extension = fileName.split(".").pop()
-
-            if (
-                extension == "mp4" ||
-                extension == "m4a" ||
-                extension == "f4v" ||
-                extension == "m4b" ||
-                extension == "mov"
-            ) {
-                return true
-            }
-            return false
-        },
-
-        parsedVideo() {
-            if (this.isVideo) {
-                let mainVideo = this.page.heroImage[0].image[0]
-                let video = {
-                    videoUrl: mainVideo.src,
-                    sizes: mainVideo.sizes,
-                    height: mainVideo.height,
-                    width: mainVideo.width,
-                    altText: mainVideo.alt,
-                    caption: mainVideo.caption,
-                    poster: mainVideo.poster,
-                }
-                return video
-            } else {
-                return {}
-            }
-        },
         parsedByline() {
             let bannerFeaturedByline = this.page.contributors.map((obj) => {
                 if (obj.typeHandle === "externalContributor") {

--- a/pages/impact/_year/index.vue
+++ b/pages/impact/_year/index.vue
@@ -30,9 +30,9 @@
             Main Story
         </h2>
         <banner-featured
-            v-if="page.keyArt && page.keyArt.length != 0 && isVideo"
+            v-if="page.keyArt && page.keyArt.length != 0"
             class="section-banner"
-            :video="parsedVideo"
+            :image="page.keyArt[0].heroImage[0]"
             :ratio="40"
             :title="page.keyArt[0].titleGeneral"
             :description="page.keyArt[0].summary"
@@ -142,40 +142,6 @@ export default {
         }
     },
     computed: {
-        isVideo() {
-            if (!this.page.keyArt) return false
-            let fileName = this.page.keyArt[0].heroImage[0].src.toLowerCase()
-            let extension = fileName.split(".").pop()
-
-            if (
-                extension == "mp4" ||
-                extension == "m4a" ||
-                extension == "f4v" ||
-                extension == "m4b" ||
-                extension == "mov"
-            ) {
-                return true
-            }
-            return false
-        },
-
-        parsedVideo() {
-            if (this.isVideo) {
-                let mainVideo = this.page.keyArt[0].heroImage[0]
-                let video = {
-                    videoUrl: mainVideo.src,
-                    sizes: mainVideo.sizes,
-                    height: mainVideo.height,
-                    width: mainVideo.width,
-                    altText: mainVideo.alt,
-                    caption: mainVideo.caption,
-                    poster: mainVideo.poster,
-                }
-                return video
-            } else {
-                return {}
-            }
-        },
         timelineSortedBySubtitle() {
             const timelineData = flattenTimeLineStructure(
                 this.page.timelineGallery

--- a/pages/impact/_year/index.vue
+++ b/pages/impact/_year/index.vue
@@ -6,7 +6,6 @@
                 class="intro"
                 v-html="page.title"
             />
-
             <responsive-image
                 v-if="page.portrait && page.portrait.length > 0"
                 :image="page.portrait[0]"


### PR DESCRIPTION
Connected to [APPS-1997](https://jira.library.ucla.edu/browse/APPS-1997)

 - Update to ucla-library-components to use new banners that internally determine image vs video

