### PR TITLE
refactor: graphQL fragmet for MediaAsset

### DIFF
--- a/gql/fragments/MediaAsset
+++ b/gql/fragments/MediaAsset
@@ -1,0 +1,8 @@
+fragment MediaAsset on AssetInterface {
+  id
+  url
+  height
+  width
+  title
+  focalPoint
+}


### PR DESCRIPTION
To be used for Images, Video, and Audio. The query sticks to the field names from craft so that MediaItem can do the mapping.