### PR TITLE
fix: resolve ginny-portrait aspect ratio

### DIFF
--- a/pages/impact/_year/index.vue
+++ b/pages/impact/_year/index.vue
@@ -217,6 +217,10 @@ export default {
         width: 100%;
         max-width: 50%;
         float: right;
+        ::v-deep
+                .media {
+                    object-fit: cover;
+                }
     }
 
     .section-banner {
@@ -240,6 +244,7 @@ export default {
     ::v-deep .grid-gallery {
         padding: 0;
     }
+
     /* .banner {
         margin: var(--space-3xl) auto;
     }*/


### PR DESCRIPTION
Adds object-fit: cover property to Ginny's image on Impact Report header

**Checklist:**

-   [x] I added github label for semantic versioning
-   [x] I double checked it looks like the designs
-   [ ] I completed any required mobile breakpoint styling
-   [ ] I completed any required hover state styling
-   [ ] I included a working spec file
-   [ ] I added notes above about how long it took to build this component
-   [x] UX has reviewed this PR
-   [x] I assigned this PR to someone to review
<img width="1748" alt="Screen Shot 2022-11-02 at 2 28 01 PM" src="https://user-images.githubusercontent.com/44713143/199605975-fb4cd59e-497a-486e-a531-89f103e558be.png">
