### PR TITLE
fix: remove all overlays from impact banners

### DIFF
--- a/pages/impact/_year/_slug.vue
+++ b/pages/impact/_year/_slug.vue
@@ -88,6 +88,16 @@ export default {
         --color-theme: var(--color-white);
         padding: 0;
     }
+
+    // refactor when option to turn off overlays is available in craft
+    ::v-deep .section-banner {
+        .gradient-no-category,
+        .molecule,
+        .hatch {
+            display: none;
+        }
+    }
+    
     // .section-banner {
     //     margin-top: 0;
     //     margin-bottom: 0;

--- a/pages/impact/_year/index.vue
+++ b/pages/impact/_year/index.vue
@@ -229,6 +229,13 @@ export default {
 
         ::v-deep {
             --banner-color-theme: var(--color-help-green-03);
+
+            // refactor when option to turn off overlays is available in craft
+            .gradient,
+            .molecule,
+            &.hatch-left .hatch {
+                display: none;
+            }
         }
     }
     ::v-deep .block-highlight .text {


### PR DESCRIPTION
- hides the gradient, molecule, and hatch from the section-banner 