### PR TITLE
feat: adds space between ginny's letter and image

### DIFF
--- a/pages/impact/_year/index.vue
+++ b/pages/impact/_year/index.vue
@@ -216,6 +216,7 @@ export default {
     .portrait-Ginny {
         width: 100%;
         max-width: 50%;
+        margin-left: 24px;
         float: right;
         ::v-deep
                 .media {


### PR DESCRIPTION
- adds space between Ginny's letter and image on desktop display to avoid text running into portrait

**Checklist:**

-   [x] I added github label for semantic versioning
-   [ ] I double checked it looks like the designs
-   [ ] I completed any required mobile breakpoint styling
-   [ ] I completed any required hover state styling
-   [ ] I included a working spec file
-   [ ] I added notes above about how long it took to build this component
-   [ ] UX has reviewed this PR
-   [x] I assigned this PR to someone to review

<img width="1355" alt="Screen Shot 2022-11-02 at 8 02 48 PM" src="https://user-images.githubusercontent.com/44713143/199640093-9d0c7ea0-be5e-48aa-a19c-f7d4d3d02990.png">


