### PR TITLE
fix: staff-directory-link

### DIFF
--- a/pages/about/programs/_slug.vue
+++ b/pages/about/programs/_slug.vue
@@ -122,11 +122,10 @@ export default {
             return _get(this.page, "buttonUrl[0].buttonUrl", "")
         },
         parsedStaffDirectory() {
-            if (this.page.viewStaffDirectory != "affiliateLibrary") {
-                return "/about/staff"
-            } else {
+            let x = this.page.viewStaffDirectory
+            if (x == "false") {
                 return ""
-            }
+            } else { return "/about/staff"}
         },
         parsedArticles() {
             return this.associatedArticles.map((obj) => {


### PR DESCRIPTION
BannerHeader and BannerText

View Staff Directory link only appears on Program entries with "Yes" radio button selected; does not appear when "No" is selected

#### Showing View Staff Directory:
http://192.168.1.119:3000/about/programs/campus-library-instructional-computing-commons-clicc
<img width="989" alt="Screen Shot 2022-11-08 at 2 38 09 PM" src="https://user-images.githubusercontent.com/751697/200691249-6b30db6c-1e07-43a5-bf4d-6808e50d5ba5.png">

#### Not showing View Staff Directory:
https://deploy-preview-539--uclalibrary-test.netlify.app/about/programs/sinai/
<img width="944" alt="Screen Shot 2022-11-08 at 2 41 21 PM" src="https://user-images.githubusercontent.com/751697/200691700-85c9cba1-23e0-44c6-946c-ceafd5f2b021.png">

