### PR TITLE
fix: mediagallery gql fix for collections detail page

### DIFF
--- a/gql/fragments/BlockMediaGalleryExtraFieldsFragment.gql
+++ b/gql/fragments/BlockMediaGalleryExtraFieldsFragment.gql
@@ -1,19 +1,37 @@
+#import "~/gql/fragments/MediaAsset.gql"
+
 fragment BlockMediaGalleryExtraFieldsFragment on ElementInterface {
     id
     sectionTitle: titleGeneral
     sectionSummary: summary
     mediaGallery: mediaGalleryExtraFields {
-        id
+        dataId: id
+        captionTitle: captionHeading
+        captionText: caption
+        altText
+        sortOrder
         ... on mediaGalleryExtraFields_image_BlockType {
-            id
-            captionTitle: captionHeading
-            captionText: caption
-            altText
-            sortOrder
-            image: imageFile {
-                ...Image
+            item: imageFile {
+                ...MediaAsset
             }
-            credit
+        }
+        ... on mediaGalleryExtraFields_audio_BlockType {
+            item: audioFile {
+                ...MediaAsset
+            }
+            embedCode: audioEmbedCode
+            coverImage {
+                ...MediaAsset
+            }
+        }
+        ... on mediaGalleryExtraFields_video_BlockType {
+            item: videoFile {
+                ...MediaAsset
+            }
+            embedCode: embedCode
+            coverImage {
+                ...MediaAsset
+            }
         }
     }
 }

--- a/gql/fragments/collections/ExhibitionsAndCollectionsFpb.gql
+++ b/gql/fragments/collections/ExhibitionsAndCollectionsFpb.gql
@@ -10,10 +10,9 @@
 #import "~/gql/fragments/BlockPullQuoteFragment"
 #import "~/gql/fragments/BlockRichTextFragment"
 #import "~/gql/fragments/BlockSimpleCardsFragment"
-#import "~/gql/fragments/BlockMediaGalleryFragment"
+#import "~/gql/fragments/BlockMediaGalleryExtraFieldsFragment"
 #import "~/gql/fragments/BlockGridGalleryCardsFragment"
 #import "~/gql/fragments/BlockImpactNumberCardsFragment"
-
 
 fragment ExhibitionsAndCollectionsFpb on ElementInterface {
     blocks: exhibitionsAndCollectionsFpb {
@@ -54,10 +53,10 @@ fragment ExhibitionsAndCollectionsFpb on ElementInterface {
         ... on exhibitionsAndCollectionsFpb_simpleCards_BlockType {
             ...BlockSimpleCardsFragment
         }
-         ... on exhibitionsAndCollectionsFpb_mediaGallery_BlockType {
-            ...BlockMediaGalleryFragment
+        ... on exhibitionsAndCollectionsFpb_mediaGallery_BlockType {
+            ...BlockMediaGalleryExtraFieldsFragment
         }
-        ... on exhibitionsAndCollectionsFpb_gridGalleryCards_BlockType  {
+        ... on exhibitionsAndCollectionsFpb_gridGalleryCards_BlockType {
             ...BlockGridGalleryCardsFragment
         }
         ... on exhibitionsAndCollectionsFpb_impactNumberCards_BlockType {

--- a/pages/collections/_slug.vue
+++ b/pages/collections/_slug.vue
@@ -56,6 +56,7 @@
         </section-wrapper>
 
         <!-- Flexible Page Blocks -->
+        {{ page.blocks[0] }}
         <flexible-blocks
             class="flexible-content"
             :blocks="page.blocks"

--- a/pages/collections/_slug.vue
+++ b/pages/collections/_slug.vue
@@ -56,7 +56,6 @@
         </section-wrapper>
 
         <!-- Flexible Page Blocks -->
-        {{ page.blocks[0] }}
         <flexible-blocks
             class="flexible-content"
             :blocks="page.blocks"


### PR DESCRIPTION
Connected to [APPS-2078](https://jira.library.ucla.edu/browse/APPS-2078)

Updates graphql to query correct content for collections media gallery FPB 
Broken on prod: https://uclalibrary.library.ucla.edu/collections/neutra-richard-and-dion-papers/?preview=true

Fixed when pointed at prod locally ![Screen Shot 2022-11-22 at 3 54 06 PM](https://user-images.githubusercontent.com/34147754/203444412-d46910e3-df70-474a-aa68-86b5e8cbf3dd.png)

