### PR TITLE
fix: Use libcal proxy to avoid CORS issue

### DIFF
--- a/plugins/scrape-formid.client.js
+++ b/plugins/scrape-formid.client.js
@@ -1,11 +1,13 @@
-export default function({$axios}, inject){
-    const libcalURL = "https://calendar.library.ucla.edu/event/"
+export default function({$axios,$config}, inject){
+    //const libcalURL = "https://calendar.library.ucla.edu/event/"
     inject('scrapeApi', {
         scrapeFormId,
     })
     async function scrapeFormId(eventId = ""){
-        const response = await fetch(libcalURL + eventId)
+        console.log("event ID:"+eventId)
+        const response = await fetch($config.libcalProxy+"event/" + eventId)
         const html = await response.text()
+        console.log("event html:"+html)
         var parser = new DOMParser()
         var doc = parser.parseFromString(html, "text/html")
         let formId = doc.querySelector("input[name='fid']").getAttribute("value") 


### PR DESCRIPTION
Connected to [APPS-2107](https://jira.library.ucla.edu/browse/APPS-2107)

This fix will override the browser CORS issue with fetching formid from libcal for the event registration,
Services Team is looking into why the register api is not working anymore.