### PR TITLE
fix: find general content pages by full uri path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,21 @@ jobs:
         ES_READ_KEY: ${{ secrets.ES_READ_KEY_TEST }}
         ES_WRITE_KEY: ${{ secrets.ES_WRITE_KEY_TEST }}
         ES_INDEX: ${{ secrets.ES_INDEX_TEST }}
+    - name: Deploy to Netlify (preview)
+      if: github.ref_name!='main'
+      uses: nwtgck/actions-netlify@v2 #
+      with:
+        production-deploy: false
+        deploy-message: https://github.com/UCLALibrary/library-website-nuxt/pull/${{ github.event.pull_request.number }}
+        alias: deploy-preview-${{ github.event.pull_request.number }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        overwrites-pull-request-comment: true
+        publish-dir: './dist'
+        fails-without-credentials: true
+        github-deployment-environment: ${{ github.event_name }}-${{ github.event.number }}
+      env:
+        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
     - uses: cypress-io/github-action@v3
       with:
         start: npx http-server ./dist -p 3000
@@ -91,18 +106,4 @@ jobs:
       env:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-    - name: Deploy to Netlify (preview)
-      if: github.ref_name!='main'
-      uses: nwtgck/actions-netlify@v2 #
-      with:
-        production-deploy: false
-        deploy-message: https://github.com/UCLALibrary/library-website-nuxt/pull/${{ github.event.pull_request.number }}
-        alias: deploy-preview-${{ github.event.pull_request.number }}
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        overwrites-pull-request-comment: true
-        publish-dir: './dist'
-        fails-without-credentials: true
-        github-deployment-environment: ${{ github.event_name }}-${{ github.event.number }}
-      env:
-        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+    

--- a/gql/queries/GeneralContentDetail.gql
+++ b/gql/queries/GeneralContentDetail.gql
@@ -1,8 +1,8 @@
 #import "~/gql/fragments/Image"
 #import "~/gql/fragments/collections/AllFpb"
 
-query GeneralContentDetail($slug: [String!]) {
-    entry(section: "generalContentPage", slug: $slug) {
+query GeneralContentDetail($path: [String!]) {
+    entry(section: "generalContentPage", uri: $path) {
         ... on generalContentPage_generalContentPage_Entry {
             id
             title

--- a/pages/_.vue
+++ b/pages/_.vue
@@ -57,32 +57,20 @@ import GENERAL_CONTENT_DETAIL from "~/gql/queries/GeneralContentDetail"
 
 export default {
     async asyncData({ $graphql, params, $elasticsearchplugin, error }) {
+        const path = params.pathMatch.replace(/^\/|\/$/g, '') // trim initial and/or final slashes
         const data = await $graphql.default.request(GENERAL_CONTENT_DETAIL, {
-            slug: params.pathMatch.substring(
-                params.pathMatch.lastIndexOf("/") + 1
-            ),
+            path: path,
         })
-        if (data && data.entry && data.entry.slug && data.entry.slug != null) {
-            console.log(
-                "General Content page slug is: " +
-                    params.pathMatch.substring(
-                        params.pathMatch.lastIndexOf("/") + 1
-                    )
-            )
-            if (data.entry.parent && data.entry.parent != null) {
-                console.log("parent exists in General content page")
-                await $elasticsearchplugin.index(
-                    data.entry,
-                    data.entry.parent && data.entry.parent.slug
-                        ? data.entry.parent.slug + "--" + data.entry.slug
-                        : data.entry.slug
-                )
-            } else await $elasticsearchplugin.index(data.entry, data.entry.slug)
+        console.log(
+            "General Content page path is: " + path
+        )
+        if (data && data.entry && data.entry.slug) {
+            $elasticsearchplugin.index(data.entry, path.replace("/", "--"))
         } else {
             error({ statusCode: 404, message: 'Page not found' })
         }
         return {
-            page: _get(data, "entry", {}),
+            page: data["entry"],
         }
     },
     head() {

--- a/plugins/elasticsearchplugin.js
+++ b/plugins/elasticsearchplugin.js
@@ -1,24 +1,30 @@
 export default function ({ $config }, inject) {
     async function index(data, slug) {
+        try{
         // eslint-disable-next-line no-undef
-        if (process.server && process.env.NODE_ENV !== "development" && data && slug) {
-            console.log(
-                "this is the elasticsearch plugin" + JSON.stringify(data)
-            )
-            const response = await fetch(
-                `${$config.esURL}/${$config.esIndex}/_doc/${slug}`,
-                {
-                    headers: {
-                        Authorization: `ApiKey ${$config.esWriteKey}`,
-                        "Content-Type": "application/json",
-                    },
-                    method: "POST",
-                    body: JSON.stringify(data),
-                }
-            )
-            console.log(response)
-        } else {
-            console.log("not indexing anything")
+            if (process.server && process.env.NODE_ENV !== "development" && data && slug) {
+                console.log(
+                    "this is the elasticsearch plugin" + JSON.stringify(data)
+                )
+                const response = await fetch(
+                    `${$config.esURL}/${$config.esIndex}/_doc/${slug}`,
+                    {
+                        headers: {
+                            Authorization: `ApiKey ${$config.esWriteKey}`,
+                            "Content-Type": "application/json",
+                        },
+                        method: "POST",
+                        body: JSON.stringify(data),
+                    }
+                )
+                console.log(response)
+            } else {
+                console.log("not indexing anything")
+            }
+        }catch (e) {
+            console.error("skip indexing if connection time out issue during builds in the mean time: "+e.message)
+            console.log("skip indexing if connection time out issue during builds in the mean time: "+e.message)
+            // throw new Error("Elastic Search Indexing failed " + e) // TODO uncomment when cause is clear
         }
     }
     inject("elasticsearchplugin", {


### PR DESCRIPTION
- fixes an issue where a final '/' (often inserted by nuxt automatically) would cause a 404
- fixes a potential issue with slug collisions of nested pages (e.g. if we had pages '/abc/def' and '/ghi/def')
