### PR TITLE
fix: window.innerWidth in Chrome devtools

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -27,7 +27,7 @@ export default {
             { charset: "utf-8" },
             {
                 name: "viewport",
-                content: "width=device-width, minimum-scale=1",
+                content: "width=device-width, initial-scale=1.0, minimum-scale=1.0",
             },
         ],
     },

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -27,7 +27,7 @@ export default {
             { charset: "utf-8" },
             {
                 name: "viewport",
-                content: "width=device-width, initial-scale=1",
+                content: "width=device-width, minimum-scale=1",
             },
         ],
     },


### PR DESCRIPTION
Fixes a fairly obscure issue where the viewport width (used to determine which header to show) was incorrect when the responsive window size was set to 1024px or smaller in Chrome devtools.

I was unable to reproduce the issue elsewhere and don't understand the full implications of this change, so I don't know if it's worth making. But as far as I can tell everything looks good.

