### PR TITLE
feat: update location detail

### DIFF
--- a/gql/queries/EventDetail.gql
+++ b/gql/queries/EventDetail.gql
@@ -188,6 +188,7 @@ query EventDetail($slug: [String!]) {
                 format: "Y-m-d\\TH:i"
                 timezone: "America/Los_Angeles"
             )
+        ongoing
         image: heroImage {
             ... on heroImage_heroImage_BlockType {
                 image {

--- a/gql/queries/EventDetail.gql
+++ b/gql/queries/EventDetail.gql
@@ -87,6 +87,7 @@ query EventDetail($slug: [String!]) {
                 format: "Y-m-d\\TH:i"
                 timezone: "America/Los_Angeles"
             )
+        ongoing
     }
     eventSeries: entry(section: "workshopOrEventSeries", slug: $slug) {
         id
@@ -110,6 +111,7 @@ query EventDetail($slug: [String!]) {
                     format: "Y-m-d\\TH:i"
                     timezone: "America/Los_Angeles"
                 )
+            ongoing
             associatedLocations {
                 ... on location_location_Entry {
                     id

--- a/gql/queries/ExhibitionsAndEventsList.gql
+++ b/gql/queries/ExhibitionsAndEventsList.gql
@@ -35,6 +35,7 @@ query EventsExhibitionsList {
                         format: "Y-m-d\\TH:i"
                         timezone: "America/Los_Angeles"
                     )
+                ongoing
                 workshopOrEventSeriesType
                 typeHandle
                 associatedLocations {
@@ -111,6 +112,7 @@ query EventsExhibitionsList {
                 format: "Y-m-d\\TH:i:s"
                 timezone: "America/Los_Angeles"
             )
+        ongoing
         text: summary
         to: uri
         category: workshopOrEventSeriesType
@@ -137,6 +139,7 @@ query EventsExhibitionsList {
                 format: "Y-m-d\\TH:i:s"
                 timezone: "America/Los_Angeles"
             )
+        ongoing
         text: summary
         to: uri
         heroImage {

--- a/gql/queries/JobOpportunitiesList.gql
+++ b/gql/queries/JobOpportunitiesList.gql
@@ -8,7 +8,7 @@ query JobOpportunitiesList {
       associatedTopics {
         title
         text: summary
-        to: uri
+        uri
         externalResourceUrl
         illustrationsResourcesAndServices
       }

--- a/gql/queries/JobStudentOpportunitiesList.gql
+++ b/gql/queries/JobStudentOpportunitiesList.gql
@@ -27,7 +27,7 @@ query StudentOpportunitiesList {
       associatedTopics {
         title
         text: summary
-        to: uri
+        uri
         externalResourceUrl
         illustrationsResourcesAndServices
       }

--- a/gql/queries/JobsList.gql
+++ b/gql/queries/JobsList.gql
@@ -8,7 +8,7 @@ query CareersList {
       associatedTopics {
         title
         text: summary
-        to: uri
+        uri
         externalResourceUrl
         illustrationsResourcesAndServices
       }

--- a/gql/queries/LocationDetail.gql
+++ b/gql/queries/LocationDetail.gql
@@ -127,8 +127,9 @@ query LocationDetail($slug: [String!]) {
     }
     associatedEvents: entries(
         section: "event"
-        relatedToEntries: { section: "location", slug: $slug }
+        orderBy: "startDateWithTime ASC"
         startDateWithTime: ">= now"
+        relatedToEntries: { section: "location", slug: $slug }
     ) {
         ... on event_event_Entry {
             id

--- a/pages/about/jobs/staff-academic-jobs/index.vue
+++ b/pages/about/jobs/staff-academic-jobs/index.vue
@@ -154,7 +154,7 @@ export default {
                     ...obj,
                     to: obj.externalResourceUrl
                         ? obj.externalResourceUrl
-                        : `/${obj.to}`,
+                        : `/${obj.uri}`,
                 }
             })
         }

--- a/pages/about/jobs/staff-academic-jobs/index.vue
+++ b/pages/about/jobs/staff-academic-jobs/index.vue
@@ -63,7 +63,7 @@
                 No positions available at this time
             </div>
         </section-wrapper>
-        <section-wrapper theme="divider" v-if="associatedTopics.length > 0">
+        <section-wrapper theme="divider" v-if="parsedAssociatedTopics.length > 0">
                 <divider-way-finder
                     class="divider"
                     color="about"
@@ -73,8 +73,8 @@
         <!-- ASSOCIATED TOPICS -->
         <section-wrapper>
             <section-cards-with-illustrations
-                v-if="associatedTopics.length > 0"
-                :items="associatedTopics"
+                v-if="parsedAssociatedTopics.length > 0"
+                :items="parsedAssociatedTopics"
                 section-title="Associated Topics"
             />
         </section-wrapper>
@@ -94,7 +94,7 @@ export default {
         const data = await $graphql.default.request(JOB_OPPORTUNITIES_LIST)
         return {
             page: _get(data, "entry", {}),
-            associatedTopics: _get(data, "entry.associatedTopics", {}),
+            //associatedTopics: _get(data, "entry.associatedTopics", {}),
             allJobs: _get(data, "allJobs", {}),
         }
     },
@@ -149,10 +149,12 @@ export default {
             })
         },
         parsedAssociatedTopics() {
-            return this.associatedTopics.map((obj) => {
+            return this.page.associatedTopics.map((obj) => {
                 return {
                     ...obj,
-                    to: `/${obj.uri}`,
+                    to: obj.externalResourceUrl
+                        ? obj.externalResourceUrl
+                        : `/${obj.to}`,
                 }
             })
         }

--- a/pages/about/programs/index.vue
+++ b/pages/about/programs/index.vue
@@ -27,7 +27,7 @@
         </section-wrapper>
 
         <section-wrapper
-            v-if="page.featuredPrograms.length > 0"
+            v-if="page.featuredPrograms.length"
             class="section-no-top-margin"
         >
             <banner-featured
@@ -43,7 +43,7 @@
                 class="banner section-featured-banner"
             />
 
-            <divider-general />
+            <divider-general v-if="parsedSectionHighlight.length"/>
 
             <section-teaser-highlight
                 v-if="parsedSectionHighlight.length"

--- a/pages/about/student-opportunities/index.vue
+++ b/pages/about/student-opportunities/index.vue
@@ -178,7 +178,7 @@ export default {
                     ...obj,
                     to: obj.externalResourceUrl
                         ? obj.externalResourceUrl
-                        : `/${obj.to}`,
+                        : `/${obj.uri}`,
                 }
             })
         }

--- a/pages/help/services-resources/_slug.vue
+++ b/pages/help/services-resources/_slug.vue
@@ -143,9 +143,8 @@
 
             <section-wrapper
                 v-if="associatedEvents.length"
-                section-title="Events in the Series"
+                section-title="Workshops in this Series"
             >
-                <divider-general />
                 <section-teaser-list
                     :items="associatedEvents"
                     class="section section-list"

--- a/pages/help/services-resources/_slug.vue
+++ b/pages/help/services-resources/_slug.vue
@@ -143,7 +143,7 @@
 
             <section-wrapper
                 v-if="associatedEvents.length"
-                section-title="Event(s) in the Series"
+                section-title="Events in the Series"
             >
                 <divider-general />
                 <section-teaser-list

--- a/pages/visit/events-exhibitions/_slug.vue
+++ b/pages/visit/events-exhibitions/_slug.vue
@@ -154,7 +154,6 @@
             </section-wrapper>
 
             <section-wrapper section-title="Events in this Series">
-                <divider-general />
                 <section-teaser-list
                     v-if="associatedEvents"
                     :items="associatedEvents"

--- a/pages/visit/locations/_slug.vue
+++ b/pages/visit/locations/_slug.vue
@@ -340,13 +340,13 @@ export default {
         },
         mergeSortEventsExhibitions() {
             return this.parsedEvents.concat(this.parsedExhibtions)
-            // .sort((a, b) =>
-            //     a.startDate > b.startDate
-            //         ? -1
-            //         : b.startDate > a.startDate
-            //             ? 1
-            // //             : 0
-            // )
+            .sort((b, a) =>
+                a.startDate > b.startDate
+                    ? -1
+                    : b.startDate > a.startDate
+                        ? 1
+                        : 0
+            )
         },
     },
 }

--- a/pages/visit/locations/_slug.vue
+++ b/pages/visit/locations/_slug.vue
@@ -322,6 +322,9 @@ export default {
                     startDate: _get(obj, "startDate", ""),
                     endDate: _get(obj, "endDate", ""),
                     category: "Exhibition",
+                    ongoing: obj.onging
+                        ? obj.ongoing === "true"
+                        : "",
                 }
             })
         },
@@ -339,14 +342,14 @@ export default {
             })
         },
         mergeSortEventsExhibitions() {
-            return this.parsedEvents.concat(this.parsedExhibtions)
-            .sort((b, a) =>
-                a.startDate > b.startDate
-                    ? -1
-                    : b.startDate > a.startDate
-                        ? 1
-                        : 0
-            )
+            return this.parsedExhibtions.concat(this.parsedEvents)
+            // .sort((b, a) =>
+            //     a.startDate > b.startDate
+            //         ? -1
+            //         : b.startDate > a.startDate
+            //             ? 1
+            //             : 0
+            // )
         },
     },
 }


### PR DESCRIPTION
Connected to [UX-527](https://jira.library.ucla.edu/browse/UX-527)
- on location detail, updates event sort order to be ascending with exhibitions (typically ongoing) listed first
- adds "ongoing" to exhibition, event series, and workshop series queries
- on program listing, updates featured display to work when only one featured program is selected
- on event and workshop series, fixes divider display for associated events
- on staff-academic-job listing, fixes associated topics link
