### PR TITLE
feat: standardize search filter spacing

### DIFF
--- a/assets/styles/global.scss
+++ b/assets/styles/global.scss
@@ -103,7 +103,7 @@ button {
     }
     .error-text {
         margin-top: var(--space-m);
-        h1 {
+        h2 {
             color: var(--color-primary-blue-05);
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
                 "sass": "^1.45.2",
                 "sass-loader": "^10.1.1",
                 "ucla-library-design-tokens": "^5.4.1",
-                "ucla-library-website-components": "^2.33.1",
+                "ucla-library-website-components": "^2.34.1",
                 "vue-svg-loader": "^0.16.0",
                 "vue-template-compiler": "^2.6.12"
             },
@@ -13899,9 +13899,9 @@
             "license": "MIT"
         },
         "node_modules/ucla-library-website-components": {
-            "version": "2.33.1",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.33.1.tgz",
-            "integrity": "sha512-KLWLtA00jEwC+oj4peZ6Tn7nYtWwvktDyTuQY/V3DEdNe/oy8BtKFsO0clIZLwD1R7IqCo75V++WHydiWLpeLw==",
+            "version": "2.34.1",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.34.1.tgz",
+            "integrity": "sha512-xcDowXUhExytLUFzg+KHZwwqWqIV5TZycqItj4i2tkvYZ4J718wcCv3+GD21CrkQTov1chUdj0XS9tR7xEokrQ==",
             "dev": true,
             "dependencies": {
                 "date-fns": "^2.28.0",
@@ -24903,9 +24903,9 @@
             "dev": true
         },
         "ucla-library-website-components": {
-            "version": "2.33.1",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.33.1.tgz",
-            "integrity": "sha512-KLWLtA00jEwC+oj4peZ6Tn7nYtWwvktDyTuQY/V3DEdNe/oy8BtKFsO0clIZLwD1R7IqCo75V++WHydiWLpeLw==",
+            "version": "2.34.1",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.34.1.tgz",
+            "integrity": "sha512-xcDowXUhExytLUFzg+KHZwwqWqIV5TZycqItj4i2tkvYZ4J718wcCv3+GD21CrkQTov1chUdj0XS9tR7xEokrQ==",
             "dev": true,
             "requires": {
                 "date-fns": "^2.28.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "sass": "^1.45.2",
         "sass-loader": "^10.1.1",
         "ucla-library-design-tokens": "^5.4.1",
-        "ucla-library-website-components": "^2.33.1",
+        "ucla-library-website-components": "^2.34.1",
         "vue-svg-loader": "^0.16.0",
         "vue-template-compiler": "^2.6.12"
     }

--- a/pages/about/news/index.vue
+++ b/pages/about/news/index.vue
@@ -73,19 +73,19 @@
             <section-staff-article-list :items="parsedNewsList" />
         </section-wrapper>
         <section-wrapper v-else-if="hits && hits.length > 0" class="section-no-top-margin">
-            <div
+            <h2
                 v-if="$route.query.q"
                 class="about-results"
             >
                 Displaying {{ hits.length }} results for
                 <strong><em>“{{ $route.query.q }}”</em></strong>
-            </div>
-            <div
+            </h2>
+            <h2
                 v-else
                 class="about-results"
             >
                 Displaying {{ hits.length }} results
-            </div>
+            </h2>
             <section-staff-article-list :items="parseHitsResults" />
         </section-wrapper>
         <section-wrapper class="section-no-top-margin" v-else-if="noResultsFound">

--- a/pages/about/news/index.vue
+++ b/pages/about/news/index.vue
@@ -406,8 +406,6 @@ export default {
 
 <style lang="scss" scoped>
 .page-news {
-    .search-margin {
-        margin: var(--space-2xl) auto;
-    }
+
 }
 </style>

--- a/pages/about/news/index.vue
+++ b/pages/about/news/index.vue
@@ -72,7 +72,7 @@
         >
             <section-staff-article-list :items="parsedNewsList" />
         </section-wrapper>
-        <section-wrapper v-else-if="hits && hits.length > 0">
+        <section-wrapper v-else-if="hits && hits.length > 0" class="section-no-top-margin">
             <div
                 v-if="$route.query.q"
                 class="about-results"
@@ -88,7 +88,7 @@
             </div>
             <section-staff-article-list :items="parseHitsResults" />
         </section-wrapper>
-        <section-wrapper v-else-if="noResultsFound">
+        <section-wrapper class="section-no-top-margin" v-else-if="noResultsFound">
             <div class="error-text">
                 <rich-text>
                     <h1>Search for “{{ $route.query.q }}” not found.</h1>

--- a/pages/about/programs/index.vue
+++ b/pages/about/programs/index.vue
@@ -68,16 +68,8 @@
             />
         </section-wrapper>
 
-        <section-wrapper
-            v-if="
-                parsedProgramsList &&
-                    parsedProgramsList.length > 0 &&
-                    hits.length == 0 &&
-                    !noResultsFound
-            "
-            theme="divider"
-        >
-            <divider-way-finder color="about" />
+        <section-wrapper theme="divider">
+            <divider-way-finder class="search-margin" />
         </section-wrapper>
 
         <section-wrapper
@@ -93,28 +85,28 @@
         </section-wrapper>
 
         <!-- RESULTS -->
-        <section-wrapper v-else-if="hits && hits.length > 0">
-            <h3
+        <section-wrapper v-else-if="hits && hits.length > 0" class="section-no-top-margin">
+            <h2
                 v-if="$route.query.q"
                 class="about-results"
             >
                 Displaying {{ hits.length }} results for
                 <strong><em>“{{ $route.query.q }}</em></strong>”
-            </h3>
-            <h3
+            </h2>
+            <h2
                 v-else
                 class="about-results"
             >
                 Displaying {{ hits.length }} results
-            </h3>
+            </h2>
             <section-staff-article-list :items="parseHitsResults" />
         </section-wrapper>
 
         <!-- NO RESULTS -->
-        <section-wrapper v-else-if="noResultsFound">
+        <section-wrapper v-else-if="noResultsFound" class="section-no-top-margin">
             <div class="error-text">
                 <rich-text>
-                    <h1>Search for “{{ $route.query.q }}” not found.</h1>
+                    <h2>Search for “{{ $route.query.q }}” not found.</h2>
                     <p>
                         We can’t find the term you are looking for on this page,
                         but we're here to help. <br>
@@ -397,9 +389,5 @@ export default {
 
 <style lang="scss" scoped>
 .page-programs {
-    .about-results {
-        margin-top: var(--space-xl);
-        margin-bottom: var(--space-l);
-    }
 }
 </style>

--- a/pages/about/programs/index.vue
+++ b/pages/about/programs/index.vue
@@ -31,7 +31,7 @@
             "
             theme="divider"
         >
-            <divider-way-finder color="about" />
+            <divider-way-finder class="search-margin" color="about" />
         </section-wrapper>
 
         <section-wrapper

--- a/pages/about/staff/index.vue
+++ b/pages/about/staff/index.vue
@@ -20,7 +20,7 @@
         />
 
         <section-wrapper theme="divider">
-            <divider-way-finder />
+            <divider-way-finder class="search-margin"/>
         </section-wrapper>
 
         <!--h4 style="margin: 30px 400px">
@@ -36,9 +36,10 @@
             ${hits.length}`
                 }}
             </h4-->
-
-        <section-wrapper>
-            <alphabetical-browse-by
+        
+        <!-- ALL STAFF -->
+        <section-wrapper v-if="page.entries" class="section-no-top-margin">
+            <alphabetical-browse-by class="browse-margin"
                 v-if="
                     (searchGenericQuery.queryFilters[
                         'subjectLibrarian.keyword'
@@ -51,13 +52,9 @@
                 :selected-letter-prop="selectedLetterProp"
                 @selectedLetter="searchBySelectedLetter"
             />
-        </section-wrapper>
-
-        <!-- ALL STAFF -->
-        <section-wrapper v-if="page.entries">
             <section-staff-list :items="parsedStaffList" />
         </section-wrapper>
-        <section-wrapper
+        <section-wrapper class="section-no-top-margin"
             v-else-if="
                 hits &&
                     hits.length > 0 &&
@@ -77,7 +74,7 @@
         </section-wrapper>
 
         <!-- SUBJECT LIBRARIANS -->
-        <section-wrapper
+        <section-wrapper class="section-no-top-margin"
             v-if="
                 searchGenericQuery.queryFilters['subjectLibrarian.keyword'] &&
                     searchGenericQuery.queryFilters['subjectLibrarian.keyword'] ===
@@ -410,6 +407,9 @@ export default {
 
 <style lang="scss" scoped>
 .page-staff {
+    .browse-margin {
+        margin-bottom: var(--space-m);
+    }
     .search-container {
         position: relative;
         width: $container-l-cta + px;

--- a/pages/collections/access/index.vue
+++ b/pages/collections/access/index.vue
@@ -23,11 +23,12 @@
                 @view-mode-change="viewModeChanger" -->
         </masthead-secondary>
 
-        <section-wrapper theme="divider">
+        <!-- TODO add divider once SearchGeneric is implemented -->
+        <!-- <section-wrapper theme="divider">
             <divider-way-finder class="search-margin" />
-        </section-wrapper>
+        </section-wrapper> -->
 
-        <section-wrapper class="section-no-top-margin">
+        <section-wrapper>
             <section-cards-with-illustrations
                 class="section"
                 :items="parsedAccessCollections"

--- a/pages/collections/access/index.vue
+++ b/pages/collections/access/index.vue
@@ -23,11 +23,11 @@
                 @view-mode-change="viewModeChanger" -->
         </masthead-secondary>
 
-        <section-wrapper>
-            <divider-way-finder class="divider divider-way-finder" />
+        <section-wrapper theme="divider">
+            <divider-way-finder class="search-margin" />
         </section-wrapper>
 
-        <section-wrapper>
+        <section-wrapper class="section-no-top-margin">
             <section-cards-with-illustrations
                 class="section"
                 :items="parsedAccessCollections"

--- a/pages/collections/explore/index.vue
+++ b/pages/collections/explore/index.vue
@@ -19,7 +19,7 @@
             :search-generic-query="searchGenericQuery"
             @search-ready="getSearchData"
         />
-        <section-wrapper
+        <section-wrapper theme="divider"
             v-if="
                 page &&
                     parsedCollectionList &&
@@ -29,12 +29,12 @@
             "
         >
             <divider-way-finder
-                class="divider-way-finder"
+                class="search-margin"
                 color="default"
             />
         </section-wrapper>
 
-        <section-wrapper
+        <section-wrapper class="section-no-top-margin"
             v-if="
                 page &&
                     parsedCollectionList &&

--- a/pages/collections/explore/index.vue
+++ b/pages/collections/explore/index.vue
@@ -19,19 +19,8 @@
             :search-generic-query="searchGenericQuery"
             @search-ready="getSearchData"
         />
-        <section-wrapper theme="divider"
-            v-if="
-                page &&
-                    parsedCollectionList &&
-                    parsedCollectionList.length &&
-                    hits.length == 0 &&
-                    !noResultsFound
-            "
-        >
-            <divider-way-finder
-                class="search-margin"
-                color="default"
-            />
+        <section-wrapper theme="divider">
+            <divider-way-finder class="search-margin" />
         </section-wrapper>
 
         <section-wrapper class="section-no-top-margin"
@@ -46,27 +35,27 @@
             <section-teaser-card :items="parsedCollectionList" />
         </section-wrapper>
 
-        <section-wrapper v-else-if="hits && hits.length > 0">
-            <div
+        <section-wrapper v-else-if="hits && hits.length > 0" class="section-no-top-margin">
+            <h2
                 v-if="$route.query.q"
                 class="about-results"
             >
                 Displaying {{ hits.length }} results for
                 <strong><em>“{{ $route.query.q }}”</em></strong>
-            </div>
-            <div
+            </h2>
+            <h2
                 v-else
                 class="about-results"
             >
                 Displaying {{ hits.length }} results
-            </div>
+            </h2>
             <section-teaser-card :items="parseHitsResults" />
         </section-wrapper>
 
-        <section-wrapper v-else>
+        <section-wrapper v-else class="section-no-top-margin">
             <div class="error-text">
                 <rich-text>
-                    <h1>Search for “{{ $route.query.q }}” not found.</h1>
+                    <h2>Search for “{{ $route.query.q }}” not found.</h2>
                     <p>
                         We can’t find the term you are looking for on this page,
                         but we're here to help. <br>

--- a/pages/give/endowments/index.vue
+++ b/pages/give/endowments/index.vue
@@ -384,9 +384,6 @@ export default {
     ::v-deep .block-highlight.is-vertical:not(.has-triangle) .image .media {
         object-fit: contain;
     }
-    .search-margin {
-        margin: var(--space-2xl) auto;
-    }
 
     ::v-deep .section-teaser-card .card {
         width: calc((100% - 32px) / 2);

--- a/pages/give/endowments/index.vue
+++ b/pages/give/endowments/index.vue
@@ -15,20 +15,10 @@
             @search-ready="getSearchData"
         />
 
-        <section-wrapper
-            v-if="
-                page &&
-                    parsedFeaturedEndowments &&
-                    parsedFeaturedEndowments.length &&
-                    hits.length == 0 &&
-                    !noResultsFound
-            "
-            theme="divider"
-        >
-            <divider-way-finder
-                class="search-margin"
-                color="about"
-            />
+        <section-wrapper theme="divider">
+            <divider-way-finder 
+            class="search-margin"
+            color="about" />
         </section-wrapper>
 
         <section-wrapper
@@ -77,27 +67,27 @@
             <!-- pagination -->
         </section-wrapper>
 
-        <section-wrapper v-else-if="hits && hits.length > 0">
-            <div
+        <section-wrapper v-else-if="hits && hits.length > 0" class="section-no-top-margin">
+            <h2
                 v-if="$route.query.q"
                 class="about-results"
             >
                 Displaying {{ hits.length }} results for
                 <strong><em>“{{ $route.query.q }}”</em></strong>
-            </div>
-            <div
+            </h2>
+            <h2
                 v-else
                 class="about-results"
             >
                 Displaying {{ hits.length }} results
-            </div>
+            </h2>
             <section-generic-list :items="parseHitsResults" />
             <!-- pagination -->
         </section-wrapper>
         <section-wrapper v-else>
             <div class="error-text">
                 <rich-text>
-                    <h1>Search for “{{ $route.query.q }}” not found.</h1>
+                    <h2>Search for “{{ $route.query.q }}” not found.</h2>
                     <p>
                         We can’t find the term you are looking for on this page,
                         but we're here to help. <br>

--- a/pages/help/_slug.vue
+++ b/pages/help/_slug.vue
@@ -11,13 +11,6 @@
             <RichText :rich-text-content="page.richText" />
         </section-wrapper>
 
-        <section-wrapper theme="divider">
-            <divider-way-finder
-                class="divider-way-finder"
-                color="help"
-            />
-        </section-wrapper>
-
         <div
             v-for="(block, index) in parsedHelpTopicBlocks"
             :key="`HelpTopicBlocksKey${index}`"

--- a/pages/help/services-resources/index.vue
+++ b/pages/help/services-resources/index.vue
@@ -335,8 +335,6 @@ export default {
 
 <style lang="scss" scoped>
 .page-help {
-    .search-margin {
-        margin: var(--space-2xl) auto;
-    }
+    
 }
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -21,7 +21,7 @@
             />
         </section-wrapper>
 
-        <section-wrapper>
+        <section-wrapper class="section-no-top-margin">
             <section-cards-with-illustrations
                 class="section"
                 :items="parsedGetHelpWith"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -319,8 +319,7 @@ export default {
 </script>
 <style lang="scss" scoped>
 .page-home {
-    .button-more,
-    .search-margin {
+    .button-more {
         margin: var(--space-2xl) auto;
     }
 }

--- a/pages/search-site/index.vue
+++ b/pages/search-site/index.vue
@@ -10,9 +10,16 @@
             @search-ready="getSearchData"
         />
 
+        <section-wrapper theme="divider">
+            <divider-way-finder
+                class="search-margin"
+                color="default"
+            />
+        </section-wrapper>
+
         <section-wrapper
             v-if="$fetchState.pending"
-            class="results"
+            class="results section-no-top-margin"
         >
             <div> 
                 <p>...Search results loading</p>
@@ -38,11 +45,11 @@
 
             <section-wrapper
                 v-if="page && page.hits && page.hits.hits.length > 0"
-                class="meta"
+                class="meta section-no-top-margin"
             >
-                <section-wrapper class="about-results">
+                <div class="about-results">
                     Displaying {{ page.hits.length }} results for <strong><em>“{{ $route.query.q }}”</em></strong>
-                </section-wrapper>
+                </div>
                 <section-wrapper
                     v-for="(result, index) in page.hits.hits"
                     :key="`SearchResultBlock${index}`"
@@ -64,12 +71,12 @@
                     />
                 </section-wrapper>
             </section-wrapper>
-            <div
+            <section-wrapper
                 v-else
-                class="error-text"
+                class="section-no-top-margin"
             >
-                <rich-text>
-                    <h1>Search for “{{ $route.query.q }}” not found.</h1>
+                <rich-text class="error-text">
+                    <h2>Search for “{{ $route.query.q }}” not found.</h2>
                     <p>
                         We can’t find the page you are looking for, but we're
                         here to help. Try these regularly visited links or one
@@ -98,7 +105,7 @@
                         </li>
                     </ul>
                 </rich-text>
-            </div>
+            </section-wrapper>
 
             <section-wrapper>
                 <divider-way-finder class="divider-way-finder" />

--- a/pages/search-site/index.vue
+++ b/pages/search-site/index.vue
@@ -47,9 +47,9 @@
                 v-if="page && page.hits && page.hits.hits.length > 0"
                 class="meta section-no-top-margin"
             >
-                <div class="about-results">
+                <h2 class="about-results">
                     Displaying {{ page.hits.length }} results for <strong><em>“{{ $route.query.q }}”</em></strong>
-                </div>
+                </h2>
                 <section-wrapper
                     v-for="(result, index) in page.hits.hits"
                     :key="`SearchResultBlock${index}`"

--- a/pages/visit/events-exhibitions/index.vue
+++ b/pages/visit/events-exhibitions/index.vue
@@ -252,8 +252,6 @@ export default {
 
 <style lang="scss" scoped>
 .page-events-exhibits {
-    .search-margin {
-        margin: var(--space-2xl) auto;
-    }
+    
 }
 </style>

--- a/pages/visit/locations/index.vue
+++ b/pages/visit/locations/index.vue
@@ -19,13 +19,13 @@
 
         <section-wrapper theme="divider">
             <divider-way-finder
-                class="divider-way-finder"
+                class="divider-way-finder search-margin"
                 color="visit"
             />
         </section-wrapper>
 
         <!-- UCLA LIBRARIES -->
-        <section-wrapper
+        <section-wrapper class ="section-no-top-margin"
             v-if="
                 page &&
                     uclaLibraries &&

--- a/pages/visit/locations/index.vue
+++ b/pages/visit/locations/index.vue
@@ -65,20 +65,22 @@
 
         <!-- RESULTS -->
 
-        <section-wrapper v-else-if="hits && hits.length > 0">
-            <h3
+        <section-wrapper 
+            v-else-if="hits && hits.length > 0"
+            class="meta section-no-top-margin">
+            <h2
                 v-if="$route.query.q"
                 class="about-results"
             >
                 Displaying {{ hits.length }} results for
                 <strong><em>“{{ $route.query.q }}</em></strong>”
-            </h3>
-            <h3
+            </h2>
+            <h2
                 v-else
                 class="about-results"
             >
                 Displaying {{ hits.length }} results
-            </h3>
+            </h2>
 
             <section-location-list
                 class="blockLocationListWrapper"
@@ -87,10 +89,10 @@
         </section-wrapper>
 
         <!-- NO RESULTS -->
-        <section-wrapper v-else-if="noResultsFound">
+        <section-wrapper v-else-if="noResultsFound" class="meta section-no-top-margin">
             <div class="error-text">
                 <rich-text>
-                    <h1>Search for “{{ $route.query.q }}” not found.</h1>
+                    <h2>Search for “{{ $route.query.q }}” not found.</h2>
                     <p>
                         We can’t find the term you are looking for on this page,
                         but we're here to help. <br>


### PR DESCRIPTION
Connected to [UX-927](https://jira.library.ucla.edu/browse/UX-927)

- standardizes index page spacing and dividers for search/filters (except for Services-Resources and Staff WIP)
- updates to use h2 for about-results text
- updates component library
