### PR TITLE
feat: APPS-2159 feat: Replace links with filtered search views

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
                 "sass": "^1.45.2",
                 "sass-loader": "^10.1.1",
                 "ucla-library-design-tokens": "^5.4.1",
-                "ucla-library-website-components": "^2.35.1",
+                "ucla-library-website-components": "^2.35.3",
                 "vue-svg-loader": "^0.16.0",
                 "vue-template-compiler": "^2.6.12"
             },
@@ -13899,9 +13899,9 @@
             "license": "MIT"
         },
         "node_modules/ucla-library-website-components": {
-            "version": "2.35.1",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.35.1.tgz",
-            "integrity": "sha512-SOZSIbNeK/p8gEBLfWlbVkKGG2VLUahER8oL37y2qC6BmeHmMSNkPXCzlqz6rwLV6tYVsxy6P4Bg9gYNfmniEA==",
+            "version": "2.35.3",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.35.3.tgz",
+            "integrity": "sha512-WZRCI/XFOUs1ezS7RSBUHetKK+WAxpUbwQzp2VT7CQyl6wwxViA21BwcasmNoSrau8yHlpZUUbwFTOzvG/sSVw==",
             "dev": true,
             "dependencies": {
                 "date-fns": "^2.28.0",
@@ -24903,9 +24903,9 @@
             "dev": true
         },
         "ucla-library-website-components": {
-            "version": "2.35.1",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.35.1.tgz",
-            "integrity": "sha512-SOZSIbNeK/p8gEBLfWlbVkKGG2VLUahER8oL37y2qC6BmeHmMSNkPXCzlqz6rwLV6tYVsxy6P4Bg9gYNfmniEA==",
+            "version": "2.35.3",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.35.3.tgz",
+            "integrity": "sha512-WZRCI/XFOUs1ezS7RSBUHetKK+WAxpUbwQzp2VT7CQyl6wwxViA21BwcasmNoSrau8yHlpZUUbwFTOzvG/sSVw==",
             "dev": true,
             "requires": {
                 "date-fns": "^2.28.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "sass": "^1.45.2",
         "sass-loader": "^10.1.1",
         "ucla-library-design-tokens": "^5.4.1",
-        "ucla-library-website-components": "^2.35.1",
+        "ucla-library-website-components": "^2.35.3",
         "vue-svg-loader": "^0.16.0",
         "vue-template-compiler": "^2.6.12"
     }

--- a/pages/about/programs/_slug.vue
+++ b/pages/about/programs/_slug.vue
@@ -149,10 +149,13 @@ export default {
         },
         parsedStaffDirectory() {
             let x = this.page.viewStaffDirectory
-            if (x == "false") {
+            if (x == "false" && this.page.title.length > 0) {
                 return ""
             } else {
-                return "/about/staff"
+                let searchLibrary = this.page.title
+                let libConcat = '/about/staff?q=&filters={\"departments.title.keyword\":[\"' + encodeURIComponent(searchLibrary) + '\"]}'
+
+                return libConcat
             }
         },
         parsedArticles() {

--- a/pages/collections/index.vue
+++ b/pages/collections/index.vue
@@ -60,7 +60,7 @@
             </nuxt-link>
         </section-wrapper>
 
-        <!-- COLLECTIONS -->
+        <!-- COLLECTION NEWS -->
         <section-wrapper>
             <divider-way-finder class="divider divider-way-finder" />
         </section-wrapper>
@@ -73,7 +73,7 @@
             <smart-link
                 v-if="pageArticleCount > 3"
                 class="button-more"
-                to="/about/news"
+                :to="allCollectionsNewsLink"
             >
                 <button-more text="See All Collections News" />
             </smart-link>
@@ -204,7 +204,17 @@ export default {
             } else {
                 return []
             }
-        },  
+        },
+        allCollectionsNewsLink() {
+            let searchLibrary = "Collections"
+            let libConcat = '/about/news?q=&filters={\"category.title.keyword\":[\"' + encodeURIComponent(searchLibrary) + '\"]}'
+
+            if (this.page.locationType != "affiliateLibrary") {
+                return libConcat
+            } else {
+                return ""
+            }
+        }
     },
     methods: {
         parsedDate(postDate) {

--- a/pages/collections/index.vue
+++ b/pages/collections/index.vue
@@ -206,10 +206,10 @@ export default {
             }
         },
         allCollectionsNewsLink() {
-            let searchLibrary = "Collections"
-            let libConcat = '/about/news?q=&filters={\"category.title.keyword\":[\"' + encodeURIComponent(searchLibrary) + '\"]}'
-
             if (this.page.locationType != "affiliateLibrary") {
+                let searchLibrary = "Collections"
+                let libConcat = '/about/news?q=&filters={\"category.title.keyword\":[\"' + encodeURIComponent(searchLibrary) + '\"]}'
+
                 return libConcat
             } else {
                 return ""

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -287,11 +287,7 @@ export default {
                         : `/${bannerFeaturedNews.to}`,
                 image: _get(bannerFeaturedNews, "heroImage[0].image[0]", null),
                 // startDate: _get(bannerFeaturedNews, "postDate", null),
-                category: _get(
-                    bannerFeaturedNews,
-                    "articleCategories[0].title",
-                    ""
-                ),
+                category: this.parseArticleCategory(bannerFeaturedNews.articleCategories),
                 description: _get(bannerFeaturedNews, "text", ""),
                 startDate: _get(bannerFeaturedNews, "postDate", ""),
                 endDate: _get(bannerFeaturedNews, "postDate", ""),
@@ -305,7 +301,7 @@ export default {
                     ...obj,
                     to: `/${obj.uri}`,
                     image: _get(obj, "heroImage[0].image[0]", ""),
-                    category: _get(obj, "articleCategories[0].title", ""),
+                    category: this.parseArticleCategory(obj.articleCategories),
                     startDate: _get(obj, "postDate", ""),
                     endDate: _get(obj, "postDate", ""),
                 }
@@ -318,6 +314,16 @@ export default {
     //     const searchResponse = await this.$dataApi.siteSearch("test")
     //     console.log("Search Response: " + JSON.stringify(searchResponse))
     // },
+    methods: {
+        parseArticleCategory(categories) {
+            if (!categories || categories.length == 0) return ""
+            let result = ""
+            categories.forEach((obj) => {
+                result = result + obj.title + ", "
+            })
+            return result.slice(0, -2)
+        },
+    }
 }
 </script>
 <style lang="scss" scoped>

--- a/pages/visit/locations/_slug.vue
+++ b/pages/visit/locations/_slug.vue
@@ -45,6 +45,7 @@
                 class="divider-way-finder"
             />
         </section-wrapper>
+
         <section-wrapper>
             <div class="section-header">
                 <div
@@ -63,6 +64,7 @@
                     v-html="page.howToGetHere"
                 />
             </div>
+
             <block-hours
                 v-if="page.libcalLocationIdForHours"
                 :lid="page.libcalLocationIdForHours"
@@ -248,8 +250,11 @@ export default {
     },
     computed: {
         parsedStaffDirectory() {
-            if (this.page.locationType != "affiliateLibrary") {
-                return "/about/staff"
+            if ( this.page.locationType != "affiliateLibrary" && this.page.title. length > 0) {
+                let searchLibrary = this.page.title
+                let libConcat = '/about/staff?q=&filters={\"locations.title.keyword\":[\"' + encodeURIComponent(searchLibrary) + '\"]}'
+
+                return libConcat
             } else {
                 return ""
             }


### PR DESCRIPTION
Connected to [APPS-2159](https://jira.library.ucla.edu/browse/APPS-2159) & Connected to [APPS-2124](https://jira.library.ucla.edu/browse/APPS-2124)

Updates Component Library to  "version": "2.35.3",

+ On Location detail: "View staff directory" link in banner --> Staff Directory listing filtered by relevant location
    + https://deploy-preview-658--uclalibrary-test.netlify.app/visit/locations/biomed/
    + https://deploy-preview-658--uclalibrary-test.netlify.app/visit/locations/data-science-center/
+ On Program detail: "View staff directory link in banner" --> Staff Directory listing filtered by relevant department (CLICC, DLP)
    + https://deploy-preview-660--uclalibrary-test.netlify.app/about/programs/digital-library-program/
    + https://deploy-preview-660--uclalibrary-test.netlify.app/about/programs/campus-library-instructional-computing-commons-clicc/
 + On Endowment detail: subject area (e.g. "Arts and Music") --> Endowment listing filtered by subject area
    SubjectArea link connects to a filtered search on the endowment Listing page
    + https://deploy-preview-659--uclalibrary-test.netlify.app/give/endowments/the-gold-shield-marjorie-alice-lenz-endowed-collection-in-fashion-and-costume-design/
    + https://deploy-preview-659--uclalibrary-test.netlify.app/give/endowments/lifu-wang-chinese-cultural-endowment/
 + On Collections landing page: "See all Collections News" button --> News listing filtered view by category
    Update the *See all Collections News* button link to go to the News page filtered by collections
    + https://deploy-preview-661--uclalibrary-test.netlify.app/collections/
<img width="1023" alt="Screen Shot 2023-02-07 at 10 12 21 PM" src="https://user-images.githubusercontent.com/751697/217449361-1dfec0eb-13f0-4e39-8007-354bc4e5c782.png">

APPS-2124 Display multiple categories on homepage news items
![Screen Shot 2023-02-08 at 12 28 10 PM](https://user-images.githubusercontent.com/751697/217643674-9bddfd90-91a5-4491-b979-3b420f937260.png)