### PR TITLE
fix: trigger auto-build.yml from on-release.yml

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [ published ]
 
+env:
+   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   set-tag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Have to use a personal access token for one workflow to trigger another – see https://github.com/orgs/community/discussions/27028