### PR TITLE
fix: update page title for homepage and error templates

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -41,7 +41,7 @@ export default {
         }
     },
     head: {
-        titleTemplate: "%s | UCLA Library",
+        titleTemplate: (title) => (title === 'Homepage' ? 'UCLA Library' : `${title}` + ' | UCLA Library'),
         script: [
             {
                 hid: "libanswers",

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -38,6 +38,9 @@ export default {
             default: () => {},
         },
     },
+    head: {
+        title: "Error",
+    },
 }
 </script>
 <style lang="scss" scoped>


### PR DESCRIPTION
Homepage is "UCLA Library": https://deploy-preview-688--uclalibrary-test.netlify.app/ 
Error is "Error | UCLA Library": https://deploy-preview-688--uclalibrary-test.netlify.app/safoeifj
Other pages are "{{page.title}} | UCLA Library": https://deploy-preview-688--uclalibrary-test.netlify.app/help/services-resources/borrowing-books-and-equipment