### PR TITLE
fix: staff contact and alt language display

### DIFF
--- a/gql/queries/CollectionDetail.gql
+++ b/gql/queries/CollectionDetail.gql
@@ -60,15 +60,27 @@ query CollectionDetail($slug: [String!]) {
     }
     associatedStaffMember {
       email
-      phoneNumber
       staffMemberJobTitle
       nameFirst
       nameLast
+      alternativeName {
+                ... on alternativeName_alternativeName_BlockType {
+                    fullName
+                    languageAltName
+                }
+            }
       to: uri
-      bookAConsultation
-      staffDepartment {
-        title
-      }
+      phone: phoneNumber
+      consultation: bookAConsultation
+      departments: staffDepartment(orderBy: "level") {
+                id
+                title
+            }
+      locations: staffAssociatedLocations {
+                id
+                title
+                uri: slug
+            }
       image: staffPortrait {
           ...Image
       }

--- a/gql/queries/CollectionDetail.gql
+++ b/gql/queries/CollectionDetail.gql
@@ -60,7 +60,7 @@ query CollectionDetail($slug: [String!]) {
     }
     associatedStaffMember {
       email
-      staffMemberJobTitle
+      jobTitle: staffMemberJobTitle
       nameFirst
       nameLast
       alternativeName {

--- a/pages/about/staff/index.vue
+++ b/pages/about/staff/index.vue
@@ -311,10 +311,7 @@ export default {
                     ...obj,
                     to: `/about/staff/${obj.to}`,
                     image: _get(obj, "image[0]", null),
-                    staffName:
-                        obj.alternativeName.length > 0
-                            ? `${obj.nameFirst} ${obj.nameLast} ${obj.alternativeName[0].fullName}`
-                            : `${obj.nameFirst} ${obj.nameLast}`,
+                    staffName: `${obj.nameFirst} ${obj.nameLast}`,
                     language: _get(
                         obj,
                         "alternativeName[0].languageAltName",

--- a/pages/collections/explore/_slug.vue
+++ b/pages/collections/explore/_slug.vue
@@ -204,6 +204,16 @@ export default {
                     to: `/${obj.to}`,
                     image: _get(obj, "image[0]", null),
                     staffName: `${obj.nameFirst} ${obj.nameLast}`,
+                    language: _get(
+                        obj,
+                        "alternativeName[0].languageAltName",
+                        null
+                    ),
+                    alternativeFullName: _get(
+                        obj,
+                        "alternativeName[0].fullName",
+                        null
+                    ),
                 }
             })
         },


### PR DESCRIPTION
Connected to [APPS-2282](https://jira.library.ucla.edu/browse/APPS-2282)
Connected to [WST-126](https://jira.library.ucla.edu/browse/WST-126)

- adds missing staff contact info to collection detail page
- fixes alt language name display on staff directory