### PR TITLE
fix: remove altName from staffName in parseHits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
                 "sass": "^1.45.2",
                 "sass-loader": "^10.1.1",
                 "ucla-library-design-tokens": "^5.4.1",
-                "ucla-library-website-components": "^2.36.1",
+                "ucla-library-website-components": "^2.36.2",
                 "vue-svg-loader": "^0.16.0",
                 "vue-template-compiler": "^2.6.12"
             },
@@ -13901,9 +13901,9 @@
             "license": "MIT"
         },
         "node_modules/ucla-library-website-components": {
-            "version": "2.36.1",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.36.1.tgz",
-            "integrity": "sha512-MD2lwVKueV5KbSmN9A/mgcu0usf/zQzd+O9KKnk4UanbqSqDOLPklZ/bZehBQo+LLP9cIj7Y356m/bW+ZPDx6Q==",
+            "version": "2.36.2",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.36.2.tgz",
+            "integrity": "sha512-v10BA3X6T91QAXfHfcV9vlWyPJ7Rt3JxZ1NdiBYMF5wXLZxDm+i8jDzjszuZuDj4N0yMTzNjxTp48Nh4YfpOlA==",
             "dev": true,
             "dependencies": {
                 "date-fns": "^2.28.0",
@@ -24907,9 +24907,9 @@
             "dev": true
         },
         "ucla-library-website-components": {
-            "version": "2.36.1",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.36.1.tgz",
-            "integrity": "sha512-MD2lwVKueV5KbSmN9A/mgcu0usf/zQzd+O9KKnk4UanbqSqDOLPklZ/bZehBQo+LLP9cIj7Y356m/bW+ZPDx6Q==",
+            "version": "2.36.2",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.36.2.tgz",
+            "integrity": "sha512-v10BA3X6T91QAXfHfcV9vlWyPJ7Rt3JxZ1NdiBYMF5wXLZxDm+i8jDzjszuZuDj4N0yMTzNjxTp48Nh4YfpOlA==",
             "dev": true,
             "requires": {
                 "date-fns": "^2.28.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "sass": "^1.45.2",
         "sass-loader": "^10.1.1",
         "ucla-library-design-tokens": "^5.4.1",
-        "ucla-library-website-components": "^2.36.1",
+        "ucla-library-website-components": "^2.36.2",
         "vue-svg-loader": "^0.16.0",
         "vue-template-compiler": "^2.6.12"
     }

--- a/pages/about/staff/index.vue
+++ b/pages/about/staff/index.vue
@@ -384,10 +384,7 @@ export default {
                         obj["_source"].alternativeName.length > 0
                             ? obj["_source"].alternativeName[0].languageAltName
                             : null,
-                    staffName:
-                        obj["_source"].alternativeName.length > 0
-                            ? `${obj["_source"].nameFirst} ${obj["_source"].nameLast} ${obj["_source"].alternativeName[0].fullName}`
-                            : `${obj["_source"].nameFirst} ${obj["_source"].nameLast}`,
+                    staffName: `${obj["_source"].nameFirst} ${obj["_source"].nameLast}`,
                 }
             })
         },


### PR DESCRIPTION
Connected to [WST-126](https://jira.library.ucla.edu/browse/WST-126)

- Removes altName from staffName in parseHits. Staff name should now appear correct on staff directory index from page load and search results load
