### PR TITLE
fix: check length of heroimage array, getting empty array from craft

### DIFF
--- a/cypress/e2e/eventsexhibitionslist.cy.js
+++ b/cypress/e2e/eventsexhibitionslist.cy.js
@@ -8,7 +8,7 @@ describe("Events & Exhibitions List page", () => {
         cy.get("h1.title").should("contain", "Events & Exhibitions")
         cy.percySnapshot({ widths: [768, 992, 1200] })
     })
-    it("Visit Locations Listing page filter by category", () => {
+    it("Visit Events & Exhibitions Listing page filter by event type", () => {
         cy.visit('/visit/events-exhibitions/?q&filters=%7B"eventType.title.keyword"%3A%5B"Workshop"%5D%7D')
 
         cy.get ('h2.about-results').should("be.visible")

--- a/utils/flattenTimeLineStructure.js
+++ b/utils/flattenTimeLineStructure.js
@@ -8,7 +8,6 @@
 function flattenTimeLineStructure(timeLineData=[]) {
     let flattenedValues = []
     for(let item of timeLineData){
-        
         for(let subitem of item.gridGalleryCards) {
             let obj = {}
             obj.subtitle = item.subtitle || ""
@@ -17,7 +16,8 @@ function flattenTimeLineStructure(timeLineData=[]) {
             obj.snippet = subitem.contentLink && subitem.contentLink[0] ? subitem.contentLink[0].snippet : subitem.snippet
             obj.featured = subitem.featured === "true" ? true : false
             obj.to = subitem.contentLink && subitem.contentLink[0] ? subitem.contentLink[0].to : subitem.to
-            obj.image = subitem.contentLink && subitem.contentLink[0] && subitem.contentLink[0].heroImage ? subitem.contentLink[0].heroImage[0].image[0] : subitem.image ? subitem.image[0] : {}
+            //console.log("subitem content link:",subitem)
+            obj.image = subitem.contentLink && subitem.contentLink[0] && subitem.contentLink[0].heroImage && subitem.contentLink[0].heroImage.length > 0 && subitem.contentLink[0].heroImage[0].image ? subitem.contentLink[0].heroImage[0].image[0] : subitem.image ? subitem.image[0] : {}
             flattenedValues.push(obj)
         }
         


### PR DESCRIPTION
fix broken impact report in production due to missing hero image on an article used on the impact report