### PR TITLE
fix: location links in various pages

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -11,4 +11,5 @@ module.exports = defineConfig({
         },
         baseUrl: 'http://localhost:3000',
     },
+    retries: 2,
 })

--- a/gql/queries/CollectionDetail.gql
+++ b/gql/queries/CollectionDetail.gql
@@ -79,7 +79,7 @@ query CollectionDetail($slug: [String!]) {
       locations: staffAssociatedLocations {
                 id
                 title
-                uri: slug
+                uri
             }
       image: staffPortrait {
           ...Image

--- a/gql/queries/StaffList.gql
+++ b/gql/queries/StaffList.gql
@@ -26,7 +26,7 @@ query StaffList {
             locations: staffAssociatedLocations {
                 id
                 title
-                uri: slug
+                uri
             }
             image: staffPortrait {
                 ...Image

--- a/pages/about/staff/index.vue
+++ b/pages/about/staff/index.vue
@@ -138,6 +138,7 @@ import _ from "lodash"
 // GQL
 import STAFF_LIST from "~/gql/queries/StaffList"
 // UTILITIES
+import fixUri from "~/utils/fixUri"
 import getListingFilters from "~/utils/getListingFilters"
 import config from "~/utils/searchConfig"
 import removeTags from "~/utils/removeTags"
@@ -331,6 +332,12 @@ export default {
                         "alternativeName[0].fullName",
                         null
                     ),
+                    locations: _get(obj, "locations", []).map(loc => {
+                        return {
+                            ...loc,
+                            uri: fixUri(loc.uri),
+                        }
+                    }),
                 }
             })
         },
@@ -394,6 +401,12 @@ export default {
                             ? obj["_source"].alternativeName[0].languageAltName
                             : null,
                     staffName: `${obj["_source"].nameFirst} ${obj["_source"].nameLast}`,
+                    locations: _get(obj, "_source.locations", []).map(loc => {
+                        return {
+                            ...loc,
+                            uri: fixUri(loc.uri),
+                        }
+                    }),
                 }
             })
         },

--- a/pages/collections/explore/_slug.vue
+++ b/pages/collections/explore/_slug.vue
@@ -115,6 +115,7 @@
 <script>
 // HELPERS
 import _get from "lodash/get"
+import fixUri from "~/utils/fixUri"
 import removeTags from "~/utils/removeTags"
 
 // GQL
@@ -214,6 +215,12 @@ export default {
                         "alternativeName[0].fullName",
                         null
                     ),
+                    locations: _get(obj, "locations", []).map(loc => {
+                        return {
+                            ...loc,
+                            uri: fixUri(loc.uri),
+                        }
+                    }),
                 }
             })
         },

--- a/pages/give/endowments/index.vue
+++ b/pages/give/endowments/index.vue
@@ -131,6 +131,7 @@ import config from "~/utils/searchConfig"
 
 // HELPERS
 import _get from "lodash/get"
+import fixUri from "~/utils/fixUri"
 import removeTags from "~/utils/removeTags"
 
 // GQL
@@ -232,8 +233,7 @@ export default {
     },
     computed: {
         parsedFeaturedEndowments() {
-            return this.page.featuredEndowments[0].featuredEndowments.map(
-                (obj) => {
+            return _get(this, "page.featuredEndowments[0].featuredEndowments", []).map((obj) => {
                     return {
                         ...obj,
                         to: `/${obj.to}`,
@@ -257,6 +257,12 @@ export default {
                 return {
                     ...obj,
                     jobPostingURL: `/${obj.uri}`,
+                    associatedLocations: _get(obj, "associatedLocations", []).map(loc => {
+                        return {
+                            ...loc,
+                            uri: fixUri(loc.uri),
+                        }
+                    }),
                     alternativeFullName: _get(
                         obj,
                         "alternativeName[0].fullName",
@@ -344,6 +350,12 @@ export default {
                         null
                     ),
                     summary: _get(obj["_source"], "text", null),
+                    associatedLocations: _get(obj["_source"], "associatedLocations", []).map(loc => {
+                        return {
+                            ...loc,
+                            uri: fixUri(loc.uri),
+                        }
+                    }),
                 }
             })
         },

--- a/utils/fixUri.js
+++ b/utils/fixUri.js
@@ -1,0 +1,11 @@
+/**
+ * Take a URI and figure out what "section" of the site it is pointing too
+ * @param {String} uri
+ * @returns {String}
+ */
+
+function fixUri(uri = "") {
+    return uri.replace(/^(?=[^/])/, '/')
+}
+
+export default fixUri


### PR DESCRIPTION
[APPS-2333](https://jira.library.ucla.edu/browse/APPS-2333) - FIX: Library Location links go to 404 pages on Block Staff List in Staff Directory and Collection Detail pages
[APPS-2334](https://jira.library.ucla.edu/browse/APPS-2334) - FIX: Library Location links go to 404 pages in filtered view of Endowments and Jobs Listing page