### PR TITLE
fix: vue redirect for /impact/all

### DIFF
--- a/pages/impact/all.vue
+++ b/pages/impact/all.vue
@@ -1,0 +1,10 @@
+<router>
+  {
+    redirect: to => {
+      // the function receives the target route as the argument
+      // a relative location doesn't start with `/`
+      // or { path: 'profile'}
+      return '/about/reports'
+    },
+  }
+</router>


### PR DESCRIPTION
because this page gets internal links in production, nuxt was building a page for it, which netlify served instead referring to _redirects