### PR TITLE
fix: APPS-2422 Change "LIBGUIDE" label on Search Results to "RESEARCH GUIDE"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "sass": "^1.45.2",
                 "sass-loader": "^10.1.1",
                 "ucla-library-design-tokens": "^5.5.0",
-                "ucla-library-website-components": "^2.38.5",
+                "ucla-library-website-components": "^2.39.0",
                 "vue-svg-loader": "^0.16.0",
                 "vue-template-compiler": "^2.6.12"
             },
@@ -13909,9 +13909,9 @@
             "dev": true
         },
         "node_modules/ucla-library-website-components": {
-            "version": "2.38.5",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.38.5.tgz",
-            "integrity": "sha512-PScq/PV7fKhEzqSdg69coKCegDQggw/GtSZ7tUtE+dM89UL6bA27leOa1QdOfp5nejp+LQKI3T6gAjO6G5GSOQ==",
+            "version": "2.39.0",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.39.0.tgz",
+            "integrity": "sha512-m2HIe3jAvbsDYgMwYRt8+U+BwmNTKck85UKx3CPkjyV9R+C7vbutau7X1OKS6QP8TkElneZH7l/9/7V9jy2/Rg==",
             "dev": true,
             "dependencies": {
                 "date-fns": "^2.28.0",
@@ -24922,9 +24922,9 @@
             "dev": true
         },
         "ucla-library-website-components": {
-            "version": "2.38.5",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.38.5.tgz",
-            "integrity": "sha512-PScq/PV7fKhEzqSdg69coKCegDQggw/GtSZ7tUtE+dM89UL6bA27leOa1QdOfp5nejp+LQKI3T6gAjO6G5GSOQ==",
+            "version": "2.39.0",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.39.0.tgz",
+            "integrity": "sha512-m2HIe3jAvbsDYgMwYRt8+U+BwmNTKck85UKx3CPkjyV9R+C7vbutau7X1OKS6QP8TkElneZH7l/9/7V9jy2/Rg==",
             "dev": true,
             "requires": {
                 "date-fns": "^2.28.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "sass": "^1.45.2",
         "sass-loader": "^10.1.1",
         "ucla-library-design-tokens": "^5.5.0",
-        "ucla-library-website-components": "^2.38.5",
+        "ucla-library-website-components": "^2.39.0",
         "vue-svg-loader": "^0.16.0",
         "vue-template-compiler": "^2.6.12"
     }

--- a/pages/search-site/index.vue
+++ b/pages/search-site/index.vue
@@ -1,8 +1,5 @@
 <template lang="html">
-    <main
-        id="main"
-        class="page page-search-site"
-    >
+    <main id="main" class="page page-search-site">
         <masthead-secondary title="Search Results" />
 
         <search-generic
@@ -13,10 +10,7 @@
         />
 
         <section-wrapper theme="divider">
-            <divider-way-finder
-                class="search-margin"
-                color="default"
-            />
+            <divider-way-finder class="search-margin" color="default" />
         </section-wrapper>
 
         <section-wrapper
@@ -28,10 +22,7 @@
             </div>
         </section-wrapper>
 
-        <section-wrapper
-            v-else-if="$fetchState.error"
-            class="results"
-        >
+        <section-wrapper v-else-if="$fetchState.error" class="results">
             <p>There is an error</p>
         </section-wrapper>
 
@@ -51,7 +42,9 @@
             >
                 <h2 class="about-results">
                     Displaying {{ page.hits.total.value }} results for
-                    <strong><em>“{{ $route.query.q }}”</em></strong>
+                    <strong
+                        ><em>“{{ $route.query.q }}”</em></strong
+                    >
                 </h2>
 
                 <section-wrapper
@@ -75,10 +68,7 @@
                     />
                 </section-wrapper>
             </section-wrapper>
-            <section-wrapper
-                v-else
-                class="section-no-top-margin"
-            >
+            <section-wrapper v-else class="section-no-top-margin">
                 <rich-text class="error-text">
                     <h2>Search for “{{ $route.query.q }}” not found.</h2>
                     <p>
@@ -88,14 +78,15 @@
                     </p>
                     <ul>
                         <li>
-                            <a
-                                href="https://library.ucla.edu"
-                            >UCLA Library Home</a>
+                            <a href="https://library.ucla.edu"
+                                >UCLA Library Home</a
+                            >
                         </li>
                         <li>
                             <a
                                 href="https://www.library.ucla.edu/research-teaching-support/research-help"
-                            >Research Help</a>
+                                >Research Help</a
+                            >
                         </li>
                         <li>
                             <a href="/help/services-resources/ask-us">Ask Us</a>
@@ -103,7 +94,8 @@
                         <li>
                             <a
                                 href="https://www.library.ucla.edu/use/access-privileges/disability-resources"
-                            >Accessibility Resources</a>
+                                >Accessibility Resources</a
+                            >
                         </li>
                     </ul>
                 </rich-text>
@@ -293,10 +285,13 @@ export default {
     methods: {
         parseCategory(sectionHandle) {
             if (!sectionHandle) return
-            return sectionHandle
-                .split(/(?=[A-Z])/)
-                .join(" ")
-                .toUpperCase()
+            if (sectionHandle == "Libguide") {
+                return "RESEARCH GUIDE"
+            } else
+                return sectionHandle
+                    .split(/(?=[A-Z])/)
+                    .join(" ")
+                    .toUpperCase()
         },
         async setFilters() {
             /*const searchAggsResponse =


### PR DESCRIPTION
Connected to [APPS-2422](https://jira.library.ucla.edu/browse/APPS-2422)

On the Library Website Search, the results list a content type label at the top of every result. The one labelled “LIBGUIDE” needs to be changed to “RESEARCH GUIDE”

<img width="837" alt="Screenshot 2023-09-19 at 4 08 00 PM" src="https://github.com/UCLALibrary/library-website-nuxt/assets/751697/7f35c02c-3ed4-4fc4-956b-cdd9327fdc82">

[APPS-2422]: https://uclalibrary.atlassian.net/browse/APPS-2422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ