### PR TITLE
chore: APPS-2055 Update component library to update richText media embed to include half and full width options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "sass": "^1.45.2",
                 "sass-loader": "^10.1.1",
                 "ucla-library-design-tokens": "^5.5.0",
-                "ucla-library-website-components": "^2.39.0",
+                "ucla-library-website-components": "^2.40.0",
                 "vue-svg-loader": "^0.16.0",
                 "vue-template-compiler": "^2.6.12"
             },
@@ -13909,9 +13909,9 @@
             "dev": true
         },
         "node_modules/ucla-library-website-components": {
-            "version": "2.39.0",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.39.0.tgz",
-            "integrity": "sha512-m2HIe3jAvbsDYgMwYRt8+U+BwmNTKck85UKx3CPkjyV9R+C7vbutau7X1OKS6QP8TkElneZH7l/9/7V9jy2/Rg==",
+            "version": "2.40.0",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.40.0.tgz",
+            "integrity": "sha512-tZ/PTn1DRbp7T4d7eQBrIcgZv2TARWcJTReYbAmWq0mpPpYk8NC+ZYxEVugatnKDuK5lEqAu+NQJY8fUAEfxOA==",
             "dev": true,
             "dependencies": {
                 "date-fns": "^2.28.0",
@@ -24922,9 +24922,9 @@
             "dev": true
         },
         "ucla-library-website-components": {
-            "version": "2.39.0",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.39.0.tgz",
-            "integrity": "sha512-m2HIe3jAvbsDYgMwYRt8+U+BwmNTKck85UKx3CPkjyV9R+C7vbutau7X1OKS6QP8TkElneZH7l/9/7V9jy2/Rg==",
+            "version": "2.40.0",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.40.0.tgz",
+            "integrity": "sha512-tZ/PTn1DRbp7T4d7eQBrIcgZv2TARWcJTReYbAmWq0mpPpYk8NC+ZYxEVugatnKDuK5lEqAu+NQJY8fUAEfxOA==",
             "dev": true,
             "requires": {
                 "date-fns": "^2.28.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "sass": "^1.45.2",
         "sass-loader": "^10.1.1",
         "ucla-library-design-tokens": "^5.5.0",
-        "ucla-library-website-components": "^2.39.0",
+        "ucla-library-website-components": "^2.40.0",
         "vue-svg-loader": "^0.16.0",
         "vue-template-compiler": "^2.6.12"
     }


### PR DESCRIPTION
Connected to [APPS-2055](https://jira.library.ucla.edu/browse/APPS-2055)


[APPS-2055]: https://uclalibrary.atlassian.net/browse/APPS-2055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ