### PR TITLE
style: APPS-2536 LibCal/Hours website widget formatting

### DIFF
--- a/static/blockCliccHours.html
+++ b/static/blockCliccHours.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Hours for Program</title>
-        <!-- The following styles are optional, feel free to modify) -->
-        <style lang="scss">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hours for Program</title>
+    <!-- The following styles are optional, feel free to modify) -->
+    <style lang="scss">
         @import url("https://use.typekit.net/xso3wzv.css");
 
         body {
@@ -34,13 +35,14 @@
         }
 
         .s-lc-hours-note {
-            color: #434343;
+            display: none;
         }
 
         .s-lc-whw-bh button {
             font-family: 'proxima-nova';
             font-size: 18px;
         }
+
 
         /* Location Name */
         .s-lc-whw-locname a {
@@ -49,12 +51,13 @@
             font-weight: 400;
             line-height: 1.6;
             letter-spacing: 0.01em;
-            color:#032d5b;
+            color: #032d5b;
             text-align: left;
         }
 
-        .s-lc-whw-locname a:hover, .s-lc-whw-subloc a:hover{
-            color:#0B6AB7;
+        .s-lc-whw-locname a:hover,
+        .s-lc-whw-subloc a:hover {
+            color: #0B6AB7;
             text-decoration: underline;
             text-decoration-color: #0aa5ff;
         }
@@ -65,14 +68,14 @@
         }
 
         /* Sub-Location Name */
-        .s-lc-whw-sublocname a{
+        .s-lc-whw-sublocname a {
             font-family: 'proxima-nova';
             font-size: 18px;
             font-weight: 400;
             line-height: 1.6;
             letter-spacing: 0.01em;
             text-align: left;
-            color:#032d5b
+            color: #032d5b
         }
 
         .s-lc-whw-footnote {
@@ -93,7 +96,8 @@
         }
 
         /* Previous / Next */
-        .s-lc-whw-pr, .s-lc-whw-ne{
+        .s-lc-whw-pr,
+        .s-lc-whw-ne {
             padding: 5px 10px;
             font-family: 'proxima-nova';
             font-size: 18px;
@@ -121,7 +125,7 @@
         }
 
         .s-lc-whw tr {
-            border-bottom:2px dotted #dcdcdb;
+            border-bottom: 2px dotted #dcdcdb;
         }
 
         .s-lc-whw>tbody>tr>td {
@@ -137,7 +141,13 @@
             text-align: left;
         }
 
-        .s-lc-time, .s-lc-allday, .s-lc-closed, .s-lc-whw-locname, .s-lc-whw-sublocname {
+        .s-lc-time,
+        .s-lc-allday,
+        .s-lc-closed,
+        .s-lc-byap,
+        .s-lc-timetxt,
+        .s-lc-whw-locname,
+        .s-lc-whw-sublocname {
             font-family: 'proxima-nova';
             font-size: 16px;
         }
@@ -194,7 +204,7 @@
             padding: 0;
             margin: -1px;
             overflow: hidden;
-            clip: rect(0,0,0,0);
+            clip: rect(0, 0, 0, 0);
             border: 0;
         }
 
@@ -208,7 +218,7 @@
         /** CLICC HACK **/
         .s-lc-whw-loc,
         .s-lc-whw-subloc {
-        display: none;
+            display: none;
         }
 
         .s-lc-whw-loc-tr-4691,
@@ -220,7 +230,7 @@
         .s-lc-whw-loc-tr-2614,
         .s-lc-whw-loc-tr-4705,
         .s-lc-whw-loc-tr-4706 {
-        display: table-row;
+            display: table-row;
         }
 
         .s-lc-whw .s-lc-whw-loc-tr-4706 {
@@ -237,45 +247,46 @@
                 /* border: 1px solid #ddd; */
                 -webkit-overflow-scrolling: touch;
             }
+
             /* .s-lc-whw td {
                 white-space: nowrap;
             } */
         }
-        </style>
+    </style>
 
-    </head>
-    <body>
-        <div
-            id="s-lc-whw"
-            class="s-lc-whw">
-        </div>
+</head>
+
+<body>
+    <div id="s-lc-whw" class="s-lc-whw">
+    </div>
     <!-- https://nuxtjs.org/docs/directory-structure/static/ -->
     <script src="//ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
 
     <script src="https://calendar.library.ucla.edu/js/hours_grid.js?002"></script>
 
     <script>
-    $(function(){
-        const queryString = window.location.search;
-        const urlParams = new URLSearchParams(queryString);
-        const lid = urlParams.get('lid')
-        const week = new $.LibCalWeeklyGrid( $("#s-lc-whw"),
-        {
-            iid: 3244,
-            lid: lid,
-            systemTime: false
+        $(function () {
+            const queryString = window.location.search;
+            const urlParams = new URLSearchParams(queryString);
+            const lid = urlParams.get('lid')
+            const week = new $.LibCalWeeklyGrid($("#s-lc-whw"),
+                {
+                    iid: 3244,
+                    lid: lid,
+                    systemTime: false
+                });
         });
-    });
 
-    // Iframe
-    function resize() {
-        var height = $(document).height();
-        console.log("Height iframe: "+height)
-        // Backwards – send message to parent
-        window.parent.postMessage(['setHeight', height], '*');
-    }
-    window.onload = () => resize();
-    window.onresize = () => resize();
+        // Iframe
+        function resize() {
+            var height = $(document).height();
+            console.log("Height iframe: " + height)
+            // Backwards – send message to parent
+            window.parent.postMessage(['setHeight', height], '*');
+        }
+        window.onload = () => resize();
+        window.onresize = () => resize();
     </script>
-    </body>
+</body>
+
 </html>

--- a/static/blockHours.html
+++ b/static/blockHours.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Hours for Location</title>
-        <!-- The following styles are optional, feel free to modify) -->
-        <style lang="scss">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hours for Location</title>
+    <!-- The following styles are optional, feel free to modify) -->
+    <style lang="scss">
         @import url("https://use.typekit.net/xso3wzv.css");
 
         body {
@@ -34,7 +35,7 @@
         }
 
         .s-lc-hours-note {
-            color: #434343;
+            display: none;
         }
 
         .s-lc-whw-bh button {
@@ -49,12 +50,13 @@
             font-weight: 400;
             line-height: 1.6;
             letter-spacing: 0.01em;
-            color:#032d5b;
+            color: #032d5b;
             text-align: left;
         }
 
-        .s-lc-whw-locname a:hover, .s-lc-whw-subloc a:hover{
-            color:#0B6AB7;
+        .s-lc-whw-locname a:hover,
+        .s-lc-whw-subloc a:hover {
+            color: #0B6AB7;
             text-decoration: underline;
             text-decoration-color: #0aa5ff;
         }
@@ -65,14 +67,14 @@
         }
 
         /* Sub-Location Name */
-        .s-lc-whw-sublocname a{
+        .s-lc-whw-sublocname a {
             font-family: 'proxima-nova';
             font-size: 18px;
             font-weight: 400;
             line-height: 1.6;
             letter-spacing: 0.01em;
             text-align: left;
-            color:#032d5b
+            color: #032d5b
         }
 
         .s-lc-whw-footnote {
@@ -93,7 +95,8 @@
         }
 
         /* Previous / Next */
-        .s-lc-whw-pr, .s-lc-whw-ne{
+        .s-lc-whw-pr,
+        .s-lc-whw-ne {
             padding: 5px 10px;
             font-family: 'proxima-nova';
             font-size: 18px;
@@ -121,7 +124,7 @@
         }
 
         .s-lc-whw tr {
-            border-bottom:2px dotted #dcdcdb;
+            border-bottom: 2px dotted #dcdcdb;
         }
 
         .s-lc-whw>tbody>tr>td {
@@ -137,7 +140,13 @@
             text-align: left;
         }
 
-        .s-lc-time, .s-lc-allday, .s-lc-closed, .s-lc-whw-locname, .s-lc-whw-sublocname {
+        .s-lc-time,
+        .s-lc-allday,
+        .s-lc-closed,
+        .s-lc-byap,
+        .s-lc-timetxt,
+        .s-lc-whw-locname,
+        .s-lc-whw-sublocname {
             font-family: 'proxima-nova';
             font-size: 16px;
         }
@@ -194,7 +203,7 @@
             padding: 0;
             margin: -1px;
             overflow: hidden;
-            clip: rect(0,0,0,0);
+            clip: rect(0, 0, 0, 0);
             border: 0;
         }
 
@@ -204,6 +213,7 @@
             font-size: 18px;
 
         }
+
         @media (max-width: 768px) {
             .s-lc-whw-cont .table-responsive {
                 width: 100%;
@@ -214,45 +224,46 @@
                 /* border: 1px solid #ddd; */
                 -webkit-overflow-scrolling: touch;
             }
+
             /* .s-lc-whw td {
                 white-space: nowrap;
             } */
         }
-        </style>
+    </style>
 
-    </head>
-    <body>
-        <div
-            id="s-lc-whw"
-            class="s-lc-whw">
-        </div>
+</head>
+
+<body>
+    <div id="s-lc-whw" class="s-lc-whw">
+    </div>
     <!-- https://nuxtjs.org/docs/directory-structure/static/ -->
     <script src="//ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
 
     <script src="https://calendar.library.ucla.edu/js/hours_grid.js?002"></script>
 
     <script>
-    $(function(){
-        const queryString = window.location.search;
-        const urlParams = new URLSearchParams(queryString);
-        const lid = urlParams.get('lid')
-        const week = new $.LibCalWeeklyGrid( $("#s-lc-whw"),
-        {
-            iid: 3244,
-            lid: lid,
-            systemTime: false
+        $(function () {
+            const queryString = window.location.search;
+            const urlParams = new URLSearchParams(queryString);
+            const lid = urlParams.get('lid')
+            const week = new $.LibCalWeeklyGrid($("#s-lc-whw"),
+                {
+                    iid: 3244,
+                    lid: lid,
+                    systemTime: false
+                });
         });
-    });
 
-    // Iframe
-    function resize() {
-        var height = $(document).height();
-        console.log("Height iframe: "+height)
-        // Backwards – send message to parent
-        window.parent.postMessage(['setHeight', height], '*');
-    }
-    window.onload = () => resize();
-    window.onresize = () => resize();
+        // Iframe
+        function resize() {
+            var height = $(document).height();
+            console.log("Height iframe: " + height)
+            // Backwards – send message to parent
+            window.parent.postMessage(['setHeight', height], '*');
+        }
+        window.onload = () => resize();
+        window.onresize = () => resize();
     </script>
-    </body>
+</body>
+
 </html>


### PR DESCRIPTION
Connected to [APPS-2536](https://jira.library.ucla.edu/browse/APPS-2536)

### 1. Fixes the Holiday Hours
<img width="552" alt="Screenshot 2024-01-26 at 10 32 58 AM" src="https://github.com/UCLALibrary/library-website-nuxt/assets/751697/3f3b54cb-521f-44b7-bba3-e1de759f3b61">

---

Add `.s-lc-byap` & `.s-lc-timetxt` To fix 2. & 3. At line 144
```
        .s-lc-time,
        .s-lc-allday,
        .s-lc-closed,
        .s-lc-byap,
        .s-lc-timetxt,
        .s-lc-whw-locname,
        .s-lc-whw-sublocname {
            font-family: 'proxima-nova';
            font-size: 16px;
        }
```

### 2. Fixes the size of `By Appointment` on the CLICC LibCal

From: (too big)
<img width="492" alt="Screenshot 2024-01-26 at 10 38 12 AM" src="https://github.com/UCLALibrary/library-website-nuxt/assets/751697/8f62a338-e9b6-476a-ba65-178a16d19e26">

To:
<img width="498" alt="Screenshot 2024-01-26 at 10 38 40 AM" src="https://github.com/UCLALibrary/library-website-nuxt/assets/751697/55d1361f-e9e0-40fd-8c37-b4d1fc9a59d0">

---

### 3. Fixes the size of  `remote/in person` on the CLICC LibCal
From: (too big)
<img width="829" alt="Screenshot 2024-01-26 at 10 36 08 AM" src="https://github.com/UCLALibrary/library-website-nuxt/assets/751697/8f578ee2-603e-4594-89bb-1714e04bf5a6">

To:
<img width="822" alt="Screenshot 2024-01-26 at 10 36 35 AM" src="https://github.com/UCLALibrary/library-website-nuxt/assets/751697/07485e65-e4c6-4a5b-ac3f-a2f07b94e2b6">



[APPS-2536]: https://uclalibrary.atlassian.net/browse/APPS-2536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ