### PR TITLE
feat: create libguides temp index and update site alert on the clientside

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
         ES_WRITE_KEY: ${{ secrets.ES_WRITE_KEY_TEST }}
         ES_INDEX: ${{ env.ES_INDEX }}-${{ github.event.pull_request.number }}
         ES_INDEX_PREFIX: ${{secrets.ES_INDEX_PREFIX_TEST}}
+        ES_TEMP_INDEX_PREFIX_LIBGUIDES: ${{secrets.ES_TEMP_INDEX_PREFIX_LIBGUIDES_TEST}}
         LIBGUIDES_ES_INDEX: ${{secrets.LIBGUIDES_ES_INDEX_TEST}}
     - name: Deploy to Netlify (preview)
       if: github.ref_name!='main'
@@ -105,6 +106,7 @@ jobs:
         ES_WRITE_KEY: ${{ secrets.ES_WRITE_KEY_TEST }}
         ES_INDEX: ${{ secrets.ES_INDEX_TEST }}
         ES_INDEX_PREFIX: ${{ secrets.ES_INDEX_PREFIX_TEST }}
+        ES_TEMP_INDEX_PREFIX_LIBGUIDES: ${{secrets.ES_TEMP_INDEX_PREFIX_LIBGUIDES_TEST}}
         LIBGUIDES_ES_INDEX: ${{secrets.LIBGUIDES_ES_INDEX_TEST}}
     - name: Deploy to Netlify (merged)
       if: github.ref_name=='main'

--- a/.github/workflows/manual-site-build.yml
+++ b/.github/workflows/manual-site-build.yml
@@ -40,6 +40,7 @@ jobs:
           echo "ES_INDEX=${{secrets.ES_INDEX_TEST}}" >> $GITHUB_ENV
           echo "ES_INDEX_PREFIX=${{secrets.ES_INDEX_PREFIX_TEST}}" >> $GITHUB_ENV
           echo "LIBGUIDES_ES_INDEX=${{secrets.LIBGUIDES_ES_INDEX_TEST}}" >> $GITHUB_ENV
+          echo "ES_TEMP_INDEX_PREFIX_LIBGUIDES=${{secrets.ES_TEMP_INDEX_PREFIX_LIBGUIDES_TEST}}" >> $GITHUB_ENV
         if: github.event.inputs.environment == 'test'
       - name: Sets env vars for stage
         run: |
@@ -51,6 +52,7 @@ jobs:
           echo "ES_INDEX=${{secrets.ES_INDEX_STAGE}}" >> $GITHUB_ENV
           echo "ES_INDEX_PREFIX=${{secrets.ES_INDEX_PREFIX_STAGE}}" >> $GITHUB_ENV
           echo "LIBGUIDES_ES_INDEX=${{secrets.LIBGUIDES_ES_INDEX_STAGE}}" >> $GITHUB_ENV
+          echo "ES_TEMP_INDEX_PREFIX_LIBGUIDES=${{secrets.ES_TEMP_INDEX_PREFIX_LIBGUIDES_STAGE}}" >> $GITHUB_ENV
         if: github.event.inputs.environment == 'stage'
       - name: Sets env vars for prod
         run: |
@@ -62,6 +64,7 @@ jobs:
           echo "ES_INDEX=${{secrets.ES_INDEX_PROD}}" >> $GITHUB_ENV
           echo "ES_INDEX_PREFIX=${{secrets.ES_INDEX_PREFIX_PROD}}" >> $GITHUB_ENV
           echo "LIBGUIDES_ES_INDEX=${{secrets.LIBGUIDES_ES_INDEX_PROD}}" >> $GITHUB_ENV
+          echo "ES_TEMP_INDEX_PREFIX_LIBGUIDES=${{secrets.ES_TEMP_INDEX_PREFIX_LIBGUIDES_PROD}}" >> $GITHUB_ENV
         if: github.event.inputs.environment == 'prod'
       - run: npm run generate
         env:
@@ -75,6 +78,7 @@ jobs:
           ES_WRITE_KEY: ${{env.ES_WRITE_KEY}}
           ES_INDEX: ${{env.ES_INDEX}}
           ES_INDEX_PREFIX: ${{env.ES_INDEX_PREFIX}}
+          ES_TEMP_INDEX_PREFIX_LIBGUIDES: ${{secrets.ES_TEMP_INDEX_PREFIX_LIBGUIDES}}
           LIBGUIDES_ES_INDEX: ${{env.LIBGUIDES_ES_INDEX}}
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v2 #

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -40,6 +40,7 @@ jobs:
         ES_WRITE_KEY: ${{ secrets.ES_WRITE_KEY_PROD }}
         ES_INDEX: ${{ secrets.ES_INDEX_PROD }}
         ES_INDEX_PREFIX: ${{ secrets.ES_INDEX_PREFIX_PROD }}
+        ES_TEMP_INDEX_PREFIX_LIBGUIDES: ${{secrets.ES_TEMP_INDEX_PREFIX_LIBGUIDES_PROD}}
         LIBGUIDES_ES_INDEX: ${{secrets.LIBGUIDES_ES_INDEX_PROD}}
     - name: Deploy to Netlify on release
       uses: nwtgck/actions-netlify@v2 #

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -34,6 +34,7 @@ jobs:
         ES_WRITE_KEY: ${{ secrets.ES_WRITE_KEY_TEST }}
         ES_INDEX: ${{ env.ES_INDEX }}
         ES_INDEX_PREFIX: ${{secrets.ES_INDEX_PREFIX_TEST}}
+        ES_TEMP_INDEX_PREFIX_LIBGUIDES: ${{secrets.ES_TEMP_INDEX_PREFIX_LIBGUIDES_TEST}}
         LIBGUIDES_ES_INDEX: ${{secrets.LIBGUIDES_ES_INDEX_TEST}}
     - uses: cypress-io/github-action@v3
       with:

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -41,7 +41,10 @@ export default {
         }
     },
     head: {
-        titleTemplate: (title) => (title === 'Homepage' ? 'UCLA Library' : `${title}` + ' | UCLA Library'),
+        titleTemplate: (title) =>
+            title === "Homepage"
+                ? "UCLA Library"
+                : `${title}` + " | UCLA Library",
         script: [
             {
                 hid: "libanswers",
@@ -84,6 +87,11 @@ export default {
             // this.$refs.skipLink.focus()
         },
     },
+    async mounted() {
+        console.log("In mounted for default layout")
+        await this.$updateSiteAlert.updateSiteAlert()
+    },
+
     // meta: [
     //     {
     //         hid: "description",

--- a/modules/swapAliasIndexGenerator.js
+++ b/modules/swapAliasIndexGenerator.js
@@ -68,6 +68,7 @@ export default function () {
             let testJsonReindex = JSON.parse(reindexBody)
 
             consola.debug("Reindex done :"+JSON.stringify(testJsonReindex))
+            this.nuxt.options.publicRuntimeConfig['esTempIndexLibguides'] = esIndex
         } catch (err) {
             consola.error("Reindex Error:", err)
             consola.error("Reindex Response body:", reindexBody)

--- a/modules/swapAliasIndexGenerator.js
+++ b/modules/swapAliasIndexGenerator.js
@@ -7,6 +7,72 @@ export default function () {
         consola.debug("In generate done hook swap alias")
         consola.debug(this.nuxt.options.publicRuntimeConfig.esTempIndex)
         consola.debug(this.nuxt.options.publicRuntimeConfig.esIndex)
+        const timeElapsed = Date.now()
+        const now = new Date(timeElapsed)
+
+        let esIndex = `${this.nuxt.options.publicRuntimeConfig.esTempIndexPrefixLibguides}-${now.toISOString().toLowerCase().replaceAll(":", "-")}`
+        consola.debug("Libguides Temp Index named:" + esIndex)
+        const tempLibGuideIndexresponse = await fetch(`${this.nuxt.options.publicRuntimeConfig.esURL}/${esIndex}`, {
+            headers: {
+                'Authorization': `ApiKey ${this.nuxt.options.privateRuntimeConfig.esWriteKey}`,
+                'Content-Type': 'application/json',
+            },
+            method: 'PUT',
+            body: JSON.stringify({
+                settings: {
+                    analysis: {
+                        analyzer: {
+                            default: {
+                                type: "custom",
+                                tokenizer: "standard",
+                                filter: ["stemmer", "lowercase", "stop", "asciifolding"],
+                            },
+                            default_search: {
+                                type: "custom",
+                                tokenizer: "standard",
+                                filter: ["stemmer", "lowercase", "stop", "asciifolding"],
+                            }
+                        },
+                    }
+                }
+            }),
+        })
+        const tempBody = await tempLibGuideIndexresponse.text()
+        try {
+            let testJsonTemp = JSON.parse(tempBody)
+
+            consola.debug("Temp libguides index created :"+JSON.stringify(testJsonTemp))
+        } catch (err) {
+            consola.error("Temp libguides index Error:", err)
+            consola.error("Temp libguides index Response body:", tempBody)
+            throw err
+        }
+        
+        const reindexResponse = await fetch(`${this.nuxt.options.publicRuntimeConfig.esURL}/_reindex`, {
+            headers: {
+                'Authorization': `ApiKey ${this.nuxt.options.privateRuntimeConfig.esWriteKey}`,
+                'Content-Type': 'application/json',
+            },
+            method: 'POST',
+            body:JSON.stringify({
+                "source": {
+                    "index": this.nuxt.options.publicRuntimeConfig.libguidesEsIndex
+                },
+                "dest": {
+                    "index": esIndex
+                }
+            })
+        })
+        const reindexBody = await reindexResponse.text()
+        try {
+            let testJsonReindex = JSON.parse(reindexBody)
+
+            consola.debug("Reindex done :"+JSON.stringify(testJsonReindex))
+        } catch (err) {
+            consola.error("Reindex Error:", err)
+            consola.error("Reindex Response body:", reindexBody)
+            throw err
+        }
         const response = await fetch(`${this.nuxt.options.publicRuntimeConfig.esURL}/_aliases`, {
             headers: {
                 'Authorization': `ApiKey ${this.nuxt.options.privateRuntimeConfig.esWriteKey}`,
@@ -23,7 +89,7 @@ export default function () {
                     },
                     {
                         "add": {
-                            "indices": [this.nuxt.options.publicRuntimeConfig.esTempIndex,this.nuxt.options.publicRuntimeConfig.libguidesEsIndex],
+                            "indices": [this.nuxt.options.publicRuntimeConfig.esTempIndex,esIndex],
                             "alias": this.nuxt.options.publicRuntimeConfig.esIndex
                         }
                     }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -21,6 +21,7 @@ export default {
         esIndexPrefix: process.env.ES_INDEX_PREFIX || "",
         esTempIndexPrefixLibguides: process.env.ES_TEMP_INDEX_PREFIX_LIBGUIDES || "",
         esTempIndex: "",
+        esTempIndexLibguides: "",
         esURL: process.env.ES_URL || "",
         libcalProxy:
             process.env.LIBCAL_ENDPOINT ||

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -19,6 +19,7 @@ export default {
         esIndex: process.env.ES_INDEX || "",
         libguidesEsIndex: process.env.LIBGUIDES_ES_INDEX || "",
         esIndexPrefix: process.env.ES_INDEX_PREFIX || "",
+        esTempIndexPrefixLibguides: process.env.ES_TEMP_INDEX_PREFIX_LIBGUIDES || "",
         esTempIndex: "",
         esURL: process.env.ES_URL || "",
         libcalProxy:
@@ -73,6 +74,7 @@ export default {
         "~/plugins/get-headers.client.js",
         "~/plugins/scrape-formid.client.js",
         "~/plugins/add-skip-to.js",
+        "~/plugins/update-library-site-alert.client.js",
     ],
 
     /*

--- a/plugins/update-library-site-alert.client.js
+++ b/plugins/update-library-site-alert.client.js
@@ -1,0 +1,9 @@
+export default function({store}, inject){
+    inject('updateSiteAlert', {
+        updateSiteAlert,
+    })
+
+    async function updateSiteAlert(){
+        await store.dispatch('updateGlobals')
+    }
+}

--- a/store/index.js
+++ b/store/index.js
@@ -142,4 +142,22 @@ export const actions = {
             throw new Error("Craft API error, trying to set globals getGlobals. " + e)
         }
     },
+    async updateGlobals({commit}) {
+        try {
+            console.log("This should be called from nuxt client plugin")
+            let globalData = await this.$graphql.default.request(GLOBALS)
+            globalData = removeEmpties(globalData.globalSets || [])
+
+            // Shape data from Craft
+            let data = Object.fromEntries(
+                globalData.map((item) => [item.handle, item] )
+            )
+            
+            
+            commit("SET_GLOBALS", data)
+            return data
+        } catch (e) {
+            throw new Error("Craft API error, trying to update globals updateGlobals. " + e)
+        }
+    },
 }


### PR DESCRIPTION


Connected to [APPS-2540](https://jira.library.ucla.edu/browse/APPS-2540)
Connected to [APPS-2579](https://jira.library.ucla.edu/browse/APPS-2579)

Notes:

This PR creates temp libguides index for the build and replaces the indes created by systems team with new one in the alias
and also we have anew client side plugin which will call store action to update global data like site alert on client side. So we dont have to rebuild the site to see the site alert changes.

[APPS-2540]: https://uclalibrary.atlassian.net/browse/APPS-2540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APPS-2579]: https://uclalibrary.atlassian.net/browse/APPS-2579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ