### PR TITLE
ci: fix cypress binary error

### DIFF
--- a/.github/workflows/setup-workspace/action.yml
+++ b/.github/workflows/setup-workspace/action.yml
@@ -15,7 +15,10 @@ runs:
     - uses: pnpm/action-setup@v2
       with:
         version: 8
-        run_install: false
+        run_install: |
+          - recursive: true
+            args: [--frozen-lockfile, --strict-peer-dependencies]
+          - args: [--global, gulp, prettier, typescript]
     - name: Get pnpm store directory
       shell: bash
       run: |
@@ -29,16 +32,6 @@ runs:
         restore-keys: |
           ${{ runner.os }}-pnpm-store-
 
-    - uses: actions/cache@v3
-      name: Cache Cypress binary
-      with:
-        path: ~/.cache/Cypress
-        key: ${{ runner.os }}-cypress-${{ hashFiles('**/package-lock.json', '**/pnpm-lock.yaml') }}
-        restore-keys: | 
-          ${{ runner.os }}-cypress-
-
     - name: Install dependencies
       shell: bash
-      run: |
-        pnpm install --frozen-lockfile
-        pnpx cypress install
+      run: pnpm install

--- a/.github/workflows/setup-workspace/action.yml
+++ b/.github/workflows/setup-workspace/action.yml
@@ -29,6 +29,16 @@ runs:
         restore-keys: |
           ${{ runner.os }}-pnpm-store-
 
+    - uses: actions/cache@v3
+      name: Cache Cypress binary
+      with:
+        path: ~/.cache/Cypress
+        key: ${{ runner.os }}-cypress-${{ hashFiles('**/package-lock.json', '**/pnpm-lock.yaml') }}
+        restore-keys: | 
+          ${{ runner.os }}-cypress-
+
     - name: Install dependencies
       shell: bash
-      run: pnpm install
+      run: |
+        pnpm install --frozen-lockfile
+        pnpx cypress install


### PR DESCRIPTION
This PR may fix:

Following error:

/usr/local/bin/npx cypress cache list
No cached binary versions were found.
/usr/local/bin/npx cypress verify
The cypress npm package is installed, but the Cypress binary is missing.

We expected the binary to be installed here: /home/runner/.cache/Cypress/12.17.4/Cypress/Cypress

Reasons it may be missing:

- You're caching 'node_modules' but are not caching this path: /home/runner/.cache/Cypress
- You ran 'npm install' at an earlier build step but did not persist: /home/runner/.cache/Cypress

Properly caching the binary will fix this error and avoid downloading and unzipping Cypress.

Alternatively, you can run 'cypress install' to download the binary again.

https://on.cypress.io/not-installed-ci-error

----------

Platform: linux-x64 (Ubuntu - 22.04)
Cypress Version: 12.17.4
Error: The process '/usr/local/bin/npx' failed with exit code 1
