### PR TITLE
feat: fix salary ranges / update ucla-library-website-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "sass": "^1.45.2",
                 "sass-loader": "^10.1.1",
                 "ucla-library-design-tokens": "^5.5.1",
-                "ucla-library-website-components": "^v2.41.5",
+                "ucla-library-website-components": "^2.41.6",
                 "vue-svg-loader": "^0.16.0",
                 "vue-template-compiler": "^2.6.12"
             },
@@ -13909,9 +13909,9 @@
             "dev": true
         },
         "node_modules/ucla-library-website-components": {
-            "version": "2.41.5",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.41.5.tgz",
-            "integrity": "sha512-V/jrDboyauWL3YfCLb0LjW+bsJU+bBdenRKZIwoF3YZCLQFXt07uOQ9kgIFNLA3lFHWcEBgiRXeDPg43f3uptA==",
+            "version": "2.41.6",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.41.6.tgz",
+            "integrity": "sha512-8Yo2uuujt5Lgfpx3IamPiKNzrKkZb8hVTZFKtoolemHxT9KGnPZYD6RDzEtgmTTZdAF3V4tViQfSNZwbChaYPA==",
             "dev": true,
             "dependencies": {
                 "date-fns": "^2.28.0",
@@ -24922,9 +24922,9 @@
             "dev": true
         },
         "ucla-library-website-components": {
-            "version": "2.41.5",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.41.5.tgz",
-            "integrity": "sha512-V/jrDboyauWL3YfCLb0LjW+bsJU+bBdenRKZIwoF3YZCLQFXt07uOQ9kgIFNLA3lFHWcEBgiRXeDPg43f3uptA==",
+            "version": "2.41.6",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.41.6.tgz",
+            "integrity": "sha512-8Yo2uuujt5Lgfpx3IamPiKNzrKkZb8hVTZFKtoolemHxT9KGnPZYD6RDzEtgmTTZdAF3V4tViQfSNZwbChaYPA==",
             "dev": true,
             "requires": {
                 "date-fns": "^2.28.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "sass": "^1.45.2",
         "sass-loader": "^10.1.1",
         "ucla-library-design-tokens": "^5.5.1",
-        "ucla-library-website-components": "^v2.41.5",
+        "ucla-library-website-components": "^2.41.6",
         "vue-svg-loader": "^0.16.0",
         "vue-template-compiler": "^2.6.12"
     }


### PR DESCRIPTION
Connected to [PR-486](https://github.com/UCLALibrary/ucla-library-website-components/pull/486)

Courtney reported a bug earlier today. The salary ranges are not showing if the department value is empty.



[PR-486]: https://uclalibrary.atlassian.net/browse/PR-486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ