### PR TITLE
feat: APPS-2662 Migrate search-site template 

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -28,7 +28,6 @@ jobs:
           ESApiKey: ${{ secrets.ESApiKey }}
           ES_READ_KEY: ${{ secrets.ES_READ_KEY_PROD }}
           ES_WRITE_KEY: ${{ secrets.ES_WRITE_KEY_PROD }}
-          ES_INDEX: ${{ secrets.ES_INDEX_PROD }}
           ES_ALIAS: ${{ secrets.ES_ALIAS_PROD }}
           ES_INDEX_PREFIX: ${{ secrets.ES_INDEX_PREFIX_PROD }}
           ES_TEMP_INDEX_PREFIX_LIBGUIDES: ${{secrets.ES_TEMP_INDEX_PREFIX_LIBGUIDES_PROD}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,6 @@ jobs:
           ESApiKey: ${{ secrets.ESApiKey }}
           ES_READ_KEY: ${{ secrets.ES_READ_KEY_TEST }}
           ES_WRITE_KEY: ${{ secrets.ES_WRITE_KEY_TEST }}
-          ES_INDEX: ${{ env.ES_INDEX }}-${{ github.event.pull_request.number }}
           ES_ALIAS: ${{ env.ES_ALIAS }}-${{ github.event.pull_request.number }}
           ES_INDEX_PREFIX: ${{secrets.ES_INDEX_PREFIX_TEST}}
           ES_TEMP_INDEX_PREFIX_LIBGUIDES: ${{secrets.ES_TEMP_INDEX_PREFIX_LIBGUIDES_TEST}}
@@ -107,7 +106,6 @@ jobs:
           ESApiKey: ${{ secrets.ESApiKey }}
           ES_READ_KEY: ${{ secrets.ES_READ_KEY_TEST }}
           ES_WRITE_KEY: ${{ secrets.ES_WRITE_KEY_TEST }}
-          ES_INDEX: ${{ secrets.ES_INDEX_TEST }}
           ES_ALIAS: ${{ secrets.ES_ALIAS_TEST }}
           ES_INDEX_PREFIX: ${{ secrets.ES_INDEX_PREFIX_TEST }}
           ES_TEMP_INDEX_PREFIX_LIBGUIDES: ${{secrets.ES_TEMP_INDEX_PREFIX_LIBGUIDES_TEST}}

--- a/.github/workflows/manual-site-build.yml
+++ b/.github/workflows/manual-site-build.yml
@@ -37,7 +37,6 @@ jobs:
           echo "NETLIFY_SITE_ID=${{secrets.NETLIFY_SITE_ID}}" >> $GITHUB_ENV
           echo "ES_READ_KEY=${{secrets.ES_READ_KEY_TEST}}" >> $GITHUB_ENV
           echo "ES_WRITE_KEY=${{secrets.ES_WRITE_KEY_TEST}}" >> $GITHUB_ENV
-          echo "ES_INDEX=${{secrets.ES_INDEX_TEST}}" >> $GITHUB_ENV
           echo "ES_ALIAS=${{secrets.ES_ALIAS_TEST}}" >> $GITHUB_ENV
           echo "ES_INDEX_PREFIX=${{secrets.ES_INDEX_PREFIX_TEST}}" >> $GITHUB_ENV
           echo "LIBGUIDES_ES_INDEX=${{secrets.LIBGUIDES_ES_INDEX_TEST}}" >> $GITHUB_ENV
@@ -50,7 +49,6 @@ jobs:
           echo "NETLIFY_SITE_ID=${{secrets.NETLIFY_STAGE_LIBRARY_SITE_ID}}" >> $GITHUB_ENV
           echo "ES_READ_KEY=${{secrets.ES_READ_KEY_STAGE}}" >> $GITHUB_ENV
           echo "ES_WRITE_KEY=${{secrets.ES_WRITE_KEY_STAGE}}" >> $GITHUB_ENV
-          echo "ES_INDEX=${{secrets.ES_INDEX_STAGE}}" >> $GITHUB_ENV
           echo "ES_ALIAS=${{secrets.ES_ALIAS_STAGE}}" >> $GITHUB_ENV
           echo "ES_INDEX_PREFIX=${{secrets.ES_INDEX_PREFIX_STAGE}}" >> $GITHUB_ENV
           echo "LIBGUIDES_ES_INDEX=${{secrets.LIBGUIDES_ES_INDEX_STAGE}}" >> $GITHUB_ENV
@@ -63,7 +61,6 @@ jobs:
           echo "NETLIFY_SITE_ID=${{secrets.NETLIFY_PROD_LIBRARY_SITE_ID}}" >> $GITHUB_ENV
           echo "ES_READ_KEY=${{secrets.ES_READ_KEY_PROD}}" >> $GITHUB_ENV
           echo "ES_WRITE_KEY=${{secrets.ES_WRITE_KEY_PROD}}" >> $GITHUB_ENV
-          echo "ES_INDEX=${{secrets.ES_INDEX_PROD}}" >> $GITHUB_ENV
           echo "ES_ALIAS=${{secrets.ES_ALIAS_PROD}}" >> $GITHUB_ENV
           echo "ES_INDEX_PREFIX=${{secrets.ES_INDEX_PREFIX_PROD}}" >> $GITHUB_ENV
           echo "LIBGUIDES_ES_INDEX=${{secrets.LIBGUIDES_ES_INDEX_PROD}}" >> $GITHUB_ENV
@@ -79,7 +76,6 @@ jobs:
           LIBCAL_ENDPOINT: ${{ secrets.LIBCAL_ENDPOINT }}
           ES_READ_KEY: ${{env.ES_READ_KEY}}
           ES_WRITE_KEY: ${{env.ES_WRITE_KEY}}
-          ES_INDEX: ${{env.ES_INDEX}}
           ES_ALIAS: ${{env.ES_ALIAS}}
           ES_INDEX_PREFIX: ${{env.ES_INDEX_PREFIX}}
           ES_TEMP_INDEX_PREFIX_LIBGUIDES: ${{secrets.ES_TEMP_INDEX_PREFIX_LIBGUIDES}}

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -37,7 +37,6 @@ jobs:
           ESApiKey: ${{ secrets.ESApiKey }}
           ES_READ_KEY: ${{ secrets.ES_READ_KEY_PROD }}
           ES_WRITE_KEY: ${{ secrets.ES_WRITE_KEY_PROD }}
-          ES_INDEX: ${{ secrets.ES_INDEX_PROD }}
           ES_ALIAS: ${{ secrets.ES_ALIAS_PROD }}
           ES_INDEX_PREFIX: ${{ secrets.ES_INDEX_PREFIX_PROD }}
           ES_TEMP_INDEX_PREFIX_LIBGUIDES: ${{secrets.ES_TEMP_INDEX_PREFIX_LIBGUIDES_PROD}}

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -16,12 +16,10 @@ jobs:
       - uses: ./.github/workflows/setup-workspace
       - name: Sets env vars for PR preview
         run: |
-          echo "ES_INDEX=${{secrets.ES_INDEX_TEST}}-percy-tests-${{ github.head_ref || github.ref_name }}" >> $GITHUB_ENV
           echo "ES_ALIAS=${{secrets.ES_ALIAS_TEST}}-percy-tests-${{ github.head_ref || github.ref_name }}" >> $GITHUB_ENV
         if: github.ref_name!='nuxt3.x'
       - name: Sets env vars for nuxt3.x merge
         run: |
-          echo "ES_INDEX=${{secrets.ES_INDEX_TEST}}" >> $GITHUB_ENV
           echo "ES_ALIAS=${{secrets.ES_ALIAS_TEST}}" >> $GITHUB_ENV
         if: github.ref_name=='nuxt3.x'
       - run: pnpm run generate
@@ -34,7 +32,6 @@ jobs:
           ESApiKey: ${{ secrets.ESApiKey }}
           ES_READ_KEY: ${{ secrets.ES_READ_KEY_TEST }}
           ES_WRITE_KEY: ${{ secrets.ES_WRITE_KEY_TEST }}
-          ES_INDEX: ${{ env.ES_INDEX }}
           ES_ALIAS: ${{ env.ES_ALIAS }}
           ES_INDEX_PREFIX: ${{secrets.ES_INDEX_PREFIX_TEST}}
           ES_TEMP_INDEX_PREFIX_LIBGUIDES: ${{secrets.ES_TEMP_INDEX_PREFIX_LIBGUIDES_TEST}}

--- a/cypress/e2e/collectionsaccesspage.cy.js
+++ b/cypress/e2e/collectionsaccesspage.cy.js
@@ -2,7 +2,7 @@ describe('Access Collection page', () => {
   it('Visit a Access Collection Page', () => {
     // prevent cypress 404 errors on slow page load
     cy.intercept('/collections/*').as('getCollectionsRoutes')
-    cy.visit('/collections/access', { failOnStatusCode: false })
+    cy.visit('/collections/access')
     cy.wait('@getCollectionsRoutes').then(() => {
       // UCLA Library brand
       cy.get('.logo-ucla').should('be.visible')

--- a/cypress/e2e/eventsexhibitionslist.cy.js
+++ b/cypress/e2e/eventsexhibitionslist.cy.js
@@ -1,18 +1,22 @@
 describe('Events & Exhibitions List page', () => {
   it('Visits a Events & Exhibitions List Page', () => {
+    cy.intercept('/visit/events-exhibitions*').as('getEventsRoutes')
     cy.visit('/visit/events-exhibitions', { timeout: 30000 })
-    cy.wait(1000)
+    cy.wait('@getEventsRoutes').then(() => {
     // UCLA Library brand
-    cy.get('.logo-ucla').should('be.visible')
+      cy.get('.logo-ucla').should('be.visible')
 
-    cy.get('.page-events-exhibits').should('be.visible')
-    cy.get('h1.title').should('contain', 'Events & Exhibitions')
-    cy.percySnapshot({ widths: [768, 992, 1200] })
+      cy.get('.page-events-exhibits').should('be.visible')
+      cy.get('h1.title').should('contain', 'Events & Exhibitions')
+      cy.percySnapshot({ widths: [768, 992, 1200] })
+    })
   })
   it('Visit Events & Exhibitions Listing page filter by event type', () => {
+    cy.intercept('/visit/events-exhibitions*').as('getEventsSearchRoutes')
     cy.visit('/visit/events-exhibitions/?q&filters=%7B"eventType.title.keyword"%3A%5B"Workshop"%5D%7D', { timeout: 30000 })
-    cy.wait(1000)
-    cy.get('.logo-ucla').should('be.visible')
-    cy.get('h2.about-results').invoke('text').should('not.be.empty')
+    cy.wait('@getEventsRoutes').then(() => {
+      cy.get('.logo-ucla').should('be.visible')
+      cy.get('h2.about-results').invoke('text').should('not.be.empty')
+    })
   })
 })

--- a/cypress/e2e/eventsexhibitionslist.cy.js
+++ b/cypress/e2e/eventsexhibitionslist.cy.js
@@ -12,7 +12,7 @@ describe('Events & Exhibitions List page', () => {
     })
   })
   it('Visit Events & Exhibitions Listing page filter by event type', () => {
-    cy.intercept('/visit/events-exhibitions*').as('getEventsSearchRoutes')
+    cy.intercept('/visit/events-exhibitions/*').as('getEventsSearchRoutes')
     cy.visit('/visit/events-exhibitions/?q&filters=%7B"eventType.title.keyword"%3A%5B"Workshop"%5D%7D', { timeout: 30000 })
     cy.wait('@getEventsSearchRoutes').then(() => {
       cy.get('.logo-ucla').should('be.visible')

--- a/cypress/e2e/eventsexhibitionslist.cy.js
+++ b/cypress/e2e/eventsexhibitionslist.cy.js
@@ -14,7 +14,7 @@ describe('Events & Exhibitions List page', () => {
   it('Visit Events & Exhibitions Listing page filter by event type', () => {
     cy.intercept('/visit/events-exhibitions*').as('getEventsSearchRoutes')
     cy.visit('/visit/events-exhibitions/?q&filters=%7B"eventType.title.keyword"%3A%5B"Workshop"%5D%7D', { timeout: 30000 })
-    cy.wait('@getEventsRoutes').then(() => {
+    cy.wait('@getEventsSearchRoutes').then(() => {
       cy.get('.logo-ucla').should('be.visible')
       cy.get('h2.about-results').invoke('text').should('not.be.empty')
     })

--- a/cypress/e2e/eventsexhibitionslist.cy.js
+++ b/cypress/e2e/eventsexhibitionslist.cy.js
@@ -1,6 +1,7 @@
 describe('Events & Exhibitions List page', () => {
   it('Visits a Events & Exhibitions List Page', () => {
-    cy.visit('/visit/events-exhibitions', { timeout: 13000 })
+    cy.visit('/visit/events-exhibitions', { timeout: 30000 })
+    cy.wait(1000)
     // UCLA Library brand
     cy.get('.logo-ucla').should('be.visible')
 
@@ -9,8 +10,9 @@ describe('Events & Exhibitions List page', () => {
     cy.percySnapshot({ widths: [768, 992, 1200] })
   })
   it('Visit Events & Exhibitions Listing page filter by event type', () => {
-    cy.visit('/visit/events-exhibitions/?q&filters=%7B"eventType.title.keyword"%3A%5B"Workshop"%5D%7D', { timeout: 13000 })
-
+    cy.visit('/visit/events-exhibitions/?q&filters=%7B"eventType.title.keyword"%3A%5B"Workshop"%5D%7D', { timeout: 30000 })
+    cy.wait(1000)
+    cy.get('.logo-ucla').should('be.visible')
     cy.get('h2.about-results').invoke('text').should('not.be.empty')
   })
 })

--- a/cypress/e2e/sitesearch.cy.js
+++ b/cypress/e2e/sitesearch.cy.js
@@ -6,7 +6,12 @@ describe('Site Search page', () => {
     cy.get('div > h2').should('contain', 'Search for “” not found.')
   })
   it('Search all', () => {
-    cy.visit('/search-site?q=*')
-    cy.get('.about-results').should('be.visible')
+    cy.visit('/search-site?q=*', { timeout: 13000 })
+    cy.get('.logo-ucla').should('be.visible')
+    cy.get('input[type=search]').should(
+      'have.value',
+      '*'
+    )
+    cy.get('h2.about-results').invoke('text').should('not.be.empty')
   })
 })

--- a/cypress/e2e/sitesearch.cy.js
+++ b/cypress/e2e/sitesearch.cy.js
@@ -1,13 +1,12 @@
-describe("Site Search page", () => {
-    it("Search blank", () => {
-        cy.visit("/search-site")
-        cy.get("h1.title").should("contain", "Search Results")
+describe('Site Search page', () => {
+  it('Search blank', () => {
+    cy.visit('/search-site')
+    cy.get('h1.title').should('contain', 'Search Results')
 
-        cy.get("div > h2").should('contain',"Search for “” not found.")
-
-    })
-    it("Search all", () => {
-        cy.visit("/search-site?q=*")
-        cy.get(".about-results").should('be.visible')
-    })
+    cy.get('div > h2').should('contain', 'Search for “” not found.')
+  })
+  it('Search all', () => {
+    cy.visit('/search-site?q=*')
+    cy.get('.about-results').should('be.visible')
+  })
 })

--- a/cypress/e2e/sitesearch.cy.js
+++ b/cypress/e2e/sitesearch.cy.js
@@ -6,8 +6,8 @@ describe('Site Search page', () => {
     cy.get('div > h2').should('contain', 'Search for “” not found.')
   })
   it('Search all', () => {
-    cy.intercept('/search-site*').as('getSearchRoutes')
-    cy.visit('/search-site?q=*', { timeout: 30000 })
+    cy.intercept('/search-site/*').as('getSearchRoutes')
+    cy.visit('/search-site/?q=*', { timeout: 30000 })
     cy.wait('@getSearchRoutes').then(() => {
       cy.get('.logo-ucla').should('be.visible')
       cy.get('input[type=search]').should(

--- a/cypress/e2e/sitesearch.cy.js
+++ b/cypress/e2e/sitesearch.cy.js
@@ -1,0 +1,13 @@
+describe("Site Search page", () => {
+    it("Search blank", () => {
+        cy.visit("/search-site")
+        cy.get("h1.title").should("contain", "Search Results")
+
+        cy.get("div > h2").should('contain',"Search for “” not found.")
+
+    })
+    it("Search all", () => {
+        cy.visit("/search-site?q=*")
+        cy.get(".about-results").should('be.visible')
+    })
+})

--- a/cypress/e2e/sitesearch.cy.js
+++ b/cypress/e2e/sitesearch.cy.js
@@ -6,13 +6,15 @@ describe('Site Search page', () => {
     cy.get('div > h2').should('contain', 'Search for “” not found.')
   })
   it('Search all', () => {
+    cy.intercept('/search-site*').as('getSearchRoutes')
     cy.visit('/search-site?q=*', { timeout: 30000 })
-    cy.wait(1000)
-    cy.get('.logo-ucla').should('be.visible')
-    cy.get('input[type=search]').should(
-      'have.value',
-      '*'
-    )
-    cy.get('h2.about-results').invoke('text').should('not.be.empty')
+    cy.wait('@getSearchRoutes').then(() => {
+      cy.get('.logo-ucla').should('be.visible')
+      cy.get('input[type=search]').should(
+        'have.value',
+        '*'
+      )
+      cy.get('h2.about-results', { timeout: 80000 }).invoke('text').should('not.be.empty')
+    })
   })
 })

--- a/cypress/e2e/sitesearch.cy.js
+++ b/cypress/e2e/sitesearch.cy.js
@@ -6,7 +6,8 @@ describe('Site Search page', () => {
     cy.get('div > h2').should('contain', 'Search for “” not found.')
   })
   it('Search all', () => {
-    cy.visit('/search-site?q=*', { timeout: 13000 })
+    cy.visit('/search-site?q=*', { timeout: 30000 })
+    cy.wait(1000)
     cy.get('.logo-ucla').should('be.visible')
     cy.get('input[type=search]').should(
       'have.value',

--- a/modules/init.js
+++ b/modules/init.js
@@ -11,7 +11,7 @@ export default defineNuxtModule({
         const timeElapsed = Date.now()
         const now = new Date(timeElapsed)
 
-        const esLibraryIndexTemp = `${nuxt.options.runtimeConfig.public.esIndexPrefix}-${now.toISOString().toLowerCase().replaceAll(':', '-')}`
+        const esLibraryIndexTemp = nuxt.options.runtimeConfig.public.esTempIndex
         console.log('Index named:' + esLibraryIndexTemp)
         // https://www.elastic.co/guide/en/elasticsearch/reference/current/flattened.html
         try {
@@ -50,11 +50,6 @@ export default defineNuxtModule({
           })
           const body = await response.text()
           const testJson = JSON.parse(body)
-
-          nuxt.options.tempIndex = esLibraryIndexTemp
-          nuxt.options.runtimeConfig.public.esTempIndex = esLibraryIndexTemp
-          const storage = await nitro.storage.setItem('esData:tempIndex', esLibraryIndexTemp) // do this to access tempindex in nuxt indexer plugin
-          console.log(await nitro.storage.getItem('esData:tempIndex'), await nitro.storage.hasItem('esData:tempIndex'))
           console.log('Index created:' + JSON.stringify(testJson))
           console.log('Elastic Search index created succesfully!')
         } catch (err) {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -31,12 +31,6 @@ export default defineNuxtConfig({
   },
 
   nitro: {
-    storage: {
-      esData: {
-        driver: 'fs',
-        base: './data/db'
-      }
-    },
     prerender: {
       crawlLinks: true,
       failOnError: false,
@@ -100,7 +94,7 @@ export default defineNuxtConfig({
       esAlias: process.env.ES_ALIAS || '',
       libguidesEsIndex: process.env.LIBGUIDES_ES_INDEX || '',
       esIndexPrefix: process.env.ES_INDEX_PREFIX || '',
-      esTempIndex: '',
+      esTempIndex: process.env.ES_INDEX_PREFIX + '-' + new Date().toISOString().toLowerCase().replaceAll(':', '-'),
       esURL: process.env.ES_URL || '',
       libcalProxy:
         process.env.LIBCAL_ENDPOINT

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
 		"nuxt-graphql-request": "^7.0.5",
 		"sass": "^1.66.1",
 		"ucla-library-design-tokens": "^5.8.0",
-		"ucla-library-website-components": "2.39.0-alpha.76"
+		"ucla-library-website-components": "2.39.0-alpha.77"
 	}
 }

--- a/pages/search-site/index.vue
+++ b/pages/search-site/index.vue
@@ -12,6 +12,7 @@ const next = ref(false)
 const prevFrom = ref(0)
 const nextFrom = ref(0)
 const size = ref(10)
+const noResultsFound = ref(false)
 const searchFilters = ref([])
 const searchGenericQuery = ref({
   queryText: route.query.q || '',
@@ -64,20 +65,17 @@ async function searchES() {
         if (previous.value) prevFrom.value = from.value - size.value
         // console.log("what is start now:" + from.value)
         // Pagination logic ends
+        noResultsFound.value = false
       } else {
+        noResultsFound.value = true
         page.value = {}
         from.value = 0
         previous.value = false
         next.value = false
       }
-      searchGenericQuery.value = {
-        queryText: route.query.q || '',
-        queryFilters:
-          (route.query.filters &&
-            JSON.parse(route.query.filters)) ||
-          {},
-      }
+
     } else {
+      noResultsFound.value = true
       page.value = {}
     }
     isSearching.value = false
@@ -242,7 +240,7 @@ function getSearchData(data) {
     </section-wrapper>
     <div v-else>
       <section-wrapper
-        v-if="page && page.hits && page.hits.hits.length > 0"
+        v-show="page && page.hits && page.hits.hits.length > 0"
         class="meta section-no-top-margin"
       >
         <h2 class="about-results">
@@ -272,7 +270,7 @@ function getSearchData(data) {
         </section-wrapper>
       </section-wrapper>
       <section-wrapper
-        v-else
+        v-show="noResultsFound"
         class="section-no-top-margin"
       >
         <rich-text class="error-text">

--- a/pages/search-site/index.vue
+++ b/pages/search-site/index.vue
@@ -1,8 +1,8 @@
 <script setup>
 // UTILITIES
-import getListingFilters from "../utils/getListingFilters"
-import config from "../utils/searchConfig"
-import queryFilterHasValues from "../utils/queryFilterHasValues"
+import getListingFilters from '../utils/getListingFilters'
+import config from '../utils/searchConfig'
+import queryFilterHasValues from '../utils/queryFilterHasValues'
 
 const route = useRoute()
 const page = ref({})
@@ -14,7 +14,7 @@ const nextFrom = ref(0)
 const size = ref(10)
 const searchFilters = ref([])
 const searchGenericQuery = ref({
-  queryText: route.query.q || "",
+  queryText: route.query.q || '',
   queryFilters:
     (route.query.filters &&
       JSON.parse(route.query.filters)) ||
@@ -25,19 +25,19 @@ const isSearching = ref(true)
 const { $dataApi } = useNuxtApp()
 async function searchES() {
   page.value = {}
-  //console.log("In fetch start")
+  // console.log("In fetch start")
   try {
     if (
-      (route.query.q && route.query.q !== "") ||
+      (route.query.q && route.query.q !== '') ||
       (route.query.filters &&
         queryFilterHasValues(
           route.query.filters,
           config.siteSearch.filters
         ))
     ) {
-      console.log("in router query in asyc data")
+      console.log('in router query in asyc data')
       page.value = await $dataApi.siteSearch(
-        route.query.q || "*",
+        route.query.q || '*',
         route.query.from || from.value,
         (route.query.filters &&
           JSON.parse(route.query.filters)) ||
@@ -49,20 +49,20 @@ async function searchES() {
         page.value.hits &&
         page.value.hits.total.value > 0
       ) {
-        //console.log("search success")
+        // console.log("search success")
         // This is pagination logic
         from.value = Number(route.query.from || 0)
-        //console.log("from 1: " + from.value)
+        // console.log("from 1: " + from.value)
         if (from.value + size.value >= page.value.hits.total.value)
           next.value = false
         else next.value = true
 
-        if (from.value == 0) previous.value = false
+        if (from.value === 0) previous.value = false
         else previous.value = true
 
         if (next.value) nextFrom.value = from.value + size.value
         if (previous.value) prevFrom.value = from.value - size.value
-        //console.log("what is start now:" + from.value)
+        // console.log("what is start now:" + from.value)
         // Pagination logic ends
       } else {
         page.value = {}
@@ -71,7 +71,7 @@ async function searchES() {
         next.value = false
       }
       searchGenericQuery.value = {
-        queryText: route.query.q || "",
+        queryText: route.query.q || '',
         queryFilters:
           (route.query.filters &&
             JSON.parse(route.query.filters)) ||
@@ -81,28 +81,28 @@ async function searchES() {
       page.value = {}
     }
     isSearching.value = false
-    //console.log("Search Response: " + JSON.stringify(this.page))
+    // console.log("Search Response: " + JSON.stringify(this.page))
   } catch (e) {
-    throw new Error("Some Error with ES search " + e)
+    throw new Error('Some Error with ES search ' + e)
   }
 }
 
 const parsedSearchResults = computed(() => {
   return page.value.hits.hits.map((obj) => {
-    if (obj._source.sectionHandle == "Libguide")
-      obj._source.sectionHandleDisplayName = "Libguide"
+    if (obj._source.sectionHandle === 'Libguide')
+      obj._source.sectionHandleDisplayName = 'Libguide'
     if (
-      obj._source.sectionHandle == "Libguide" ||
-      obj._source.sectionHandle == "externalResource" ||
-      obj._source.sectionHandle == "affiliateLibrary"
+      obj._source.sectionHandle === 'Libguide' ||
+      obj._source.sectionHandle === 'externalResource' ||
+      obj._source.sectionHandle === 'affiliateLibrary'
     ) {
       return {
-        ...obj["_source"],
+        ...obj._source,
         to: obj._source.uri ? obj._source.uri : obj._source.to,
       }
     } else {
       return {
-        ...obj["_source"],
+        ...obj._source,
         to: obj._source.uri
           ? `/${obj._source.uri}`
           : `/${obj._source.to}`,
@@ -113,34 +113,34 @@ const parsedSearchResults = computed(() => {
 const parsePrev = computed(() => {
   if (previous.value)
     return `${route.path}?q=${route.query.q}&from=${prevFrom.value}`
-  return ""
+  return ''
 })
 const parseNext = computed(() => {
   if (next.value)
     return `${route.path}?q=${route.query.q}&from=${nextFrom.value}`
-  return ""
+  return ''
 })
 const searchAdditionalResources = computed(() => {
   return [
     {
-      iconName: "illustration-book-binding",
-      to: "https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA&_ga=2.45842788.1343136842.1666633264-241535065.1664829276",
-      title: "UC Library Search",
-      text: "Locate books, journal articles, course reserves and other content at UCLA, other UC schools and beyond.",
+      iconName: 'illustration-book-binding',
+      to: 'https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA&_ga=2.45842788.1343136842.1666633264-241535065.1664829276',
+      title: 'UC Library Search',
+      text: 'Locate books, journal articles, course reserves and other content at UCLA, other UC schools and beyond.',
       isHorizontal: false,
     },
     {
-      iconName: "illustration-find-space",
-      to: "https://guides.library.ucla.edu/az.php?&_ga=2.94193502.2106042584.1646675621-1729352043.1643913957",
-      title: "A-Z Databases",
-      text: "Find the best library databases for your research.",
+      iconName: 'illustration-find-space',
+      to: 'https://guides.library.ucla.edu/az.php?&_ga=2.94193502.2106042584.1646675621-1729352043.1643913957',
+      title: 'A-Z Databases',
+      text: 'Find the best library databases for your research.',
       isHorizontal: false,
     },
     {
-      iconName: "illustration-digitized-resources",
-      to: "https://guides.library.ucla.edu/index.php",
-      title: "Library Research Guides",
-      text: "Our research guides help users of all backgrounds discover resources by subject, course, format or topic.",
+      iconName: 'illustration-digitized-resources',
+      to: 'https://guides.library.ucla.edu/index.php',
+      title: 'Library Research Guides',
+      text: 'Our research guides help users of all backgrounds discover resources by subject, course, format or topic.',
       isHorizontal: false,
     },
   ]
@@ -165,19 +165,18 @@ onMounted(async () => {
 
 function parseCategory(sectionHandle) {
   if (!sectionHandle) return
-  if (sectionHandle == "Libguide") {
-    return "RESEARCH GUIDE"
+  if (sectionHandle === 'Libguide') {
+    return 'RESEARCH GUIDE'
   } else
     return sectionHandle
       .split(/(?=[A-Z])/)
-      .join(" ")
+      .join(' ')
       .toUpperCase()
 }
-async function setFilters() {
-
+function setFilters() {
   const filters = []
   // Not using searchconfig here as types filter data comming from ES was not useful
-  let obj = {
+  const obj = {
     label: config.siteSearch.filters[0].label,
     esFieldName: config.siteSearch.filters[0].esFieldName,
     inputType: config.siteSearch.filters[0].inputType,
@@ -189,14 +188,14 @@ async function setFilters() {
         []
       ) || [],
   }
-  console.log("getlisting obj:" + JSON.stringify(obj))
+  console.log('getlisting obj:' + JSON.stringify(obj))
   filters.push(obj)
 
   searchFilters.value = filters
 }
 
-async function getSearchData(data) {
-  //const queryString = new URLSearchParams(data.filters).toString()
+function getSearchData(data) {
+  // const queryString = new URLSearchParams(data.filters).toString()
   // console.log("using url search params:" + queryString)
   try {
     useRouter().push({
@@ -207,7 +206,7 @@ async function getSearchData(data) {
       },
     })
   } catch (e) {
-    throw new Error("ES error maybe: " + e)
+    throw new Error('ES error maybe: ' + e)
   }
 }
 
@@ -232,7 +231,6 @@ async function getSearchData(data) {
         color="default"
       />
     </section-wrapper>
-
 
     <section-wrapper
       v-if="isSearching"

--- a/pages/search-site/index.vue
+++ b/pages/search-site/index.vue
@@ -1,0 +1,326 @@
+<script setup>
+// UTILITIES
+import getListingFilters from "../utils/getListingFilters"
+import config from "../utils/searchConfig"
+import queryFilterHasValues from "../utils/queryFilterHasValues"
+
+const route = useRoute()
+const page = ref({})
+const from = ref(0)
+const previous = ref(false)
+const next = ref(false)
+const prevFrom = ref(0)
+const nextFrom = ref(0)
+const size = ref(10)
+const searchFilters = ref([])
+const searchGenericQuery = ref({
+  queryText: route.query.q || "",
+  queryFilters:
+    (route.query.filters &&
+      JSON.parse(route.query.filters)) ||
+    {},
+})
+const isSearching = ref(true)
+
+const { $dataApi } = useNuxtApp()
+async function searchES() {
+  page.value = {}
+  //console.log("In fetch start")
+  try {
+    if (
+      (route.query.q && route.query.q !== "") ||
+      (route.query.filters &&
+        queryFilterHasValues(
+          route.query.filters,
+          config.siteSearch.filters
+        ))
+    ) {
+      console.log("in router query in asyc data")
+      page.value = await $dataApi.siteSearch(
+        route.query.q || "*",
+        route.query.from || from.value,
+        (route.query.filters &&
+          JSON.parse(route.query.filters)) ||
+        {},
+        config.siteSearch.sectionHandleMapping
+      )
+      if (
+        page.value &&
+        page.value.hits &&
+        page.value.hits.total.value > 0
+      ) {
+        //console.log("search success")
+        // This is pagination logic
+        from.value = Number(route.query.from || 0)
+        //console.log("from 1: " + from.value)
+        if (from.value + size.value >= page.value.hits.total.value)
+          next.value = false
+        else next.value = true
+
+        if (from.value == 0) previous.value = false
+        else previous.value = true
+
+        if (next.value) nextFrom.value = from.value + size.value
+        if (previous.value) prevFrom.value = from.value - size.value
+        //console.log("what is start now:" + from.value)
+        // Pagination logic ends
+      } else {
+        page.value = {}
+        from.value = 0
+        previous.value = false
+        next.value = false
+      }
+      searchGenericQuery.value = {
+        queryText: route.query.q || "",
+        queryFilters:
+          (route.query.filters &&
+            JSON.parse(route.query.filters)) ||
+          {},
+      }
+    } else {
+      page.value = {}
+    }
+    isSearching.value = false
+    //console.log("Search Response: " + JSON.stringify(this.page))
+  } catch (e) {
+    throw new Error("Some Error with ES search " + e)
+  }
+}
+
+const parsedSearchResults = computed(() => {
+  return page.value.hits.hits.map((obj) => {
+    if (obj._source.sectionHandle == "Libguide")
+      obj._source.sectionHandleDisplayName = "Libguide"
+    if (
+      obj._source.sectionHandle == "Libguide" ||
+      obj._source.sectionHandle == "externalResource" ||
+      obj._source.sectionHandle == "affiliateLibrary"
+    ) {
+      return {
+        ...obj["_source"],
+        to: obj._source.uri ? obj._source.uri : obj._source.to,
+      }
+    } else {
+      return {
+        ...obj["_source"],
+        to: obj._source.uri
+          ? `/${obj._source.uri}`
+          : `/${obj._source.to}`,
+      }
+    }
+  })
+})
+const parsePrev = computed(() => {
+  if (previous.value)
+    return `${route.path}?q=${route.query.q}&from=${prevFrom.value}`
+  return ""
+})
+const parseNext = computed(() => {
+  if (next.value)
+    return `${route.path}?q=${route.query.q}&from=${nextFrom.value}`
+  return ""
+})
+const searchAdditionalResources = computed(() => {
+  return [
+    {
+      iconName: "illustration-book-binding",
+      to: "https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA&_ga=2.45842788.1343136842.1666633264-241535065.1664829276",
+      title: "UC Library Search",
+      text: "Locate books, journal articles, course reserves and other content at UCLA, other UC schools and beyond.",
+      isHorizontal: false,
+    },
+    {
+      iconName: "illustration-find-space",
+      to: "https://guides.library.ucla.edu/az.php?&_ga=2.94193502.2106042584.1646675621-1729352043.1643913957",
+      title: "A-Z Databases",
+      text: "Find the best library databases for your research.",
+      isHorizontal: false,
+    },
+    {
+      iconName: "illustration-digitized-resources",
+      to: "https://guides.library.ucla.edu/index.php",
+      title: "Library Research Guides",
+      text: "Our research guides help users of all backgrounds discover resources by subject, course, format or topic.",
+      isHorizontal: false,
+    },
+  ]
+})
+
+// This watcher is called when router push updates the query params
+watch(
+  () => route.query,
+  (newVal, oldVal) => {
+    console.log('ES newVal, oldVal', newVal, oldVal)
+    searchGenericQuery.value.queryText = route.query.q || ''
+    searchGenericQuery.value.queryFilters = (route.query.filters && JSON.parse(route.query.filters)) || {}
+    searchES()
+  }, { deep: true, immediate: true }
+)
+onMounted(async () => {
+  console.log('onMounted called')
+  // console.log("ESREADkey:" + config.esReadKey)
+  // console.log("ESURLkey:" + config.esURL)
+  await setFilters()
+})
+
+function parseCategory(sectionHandle) {
+  if (!sectionHandle) return
+  if (sectionHandle == "Libguide") {
+    return "RESEARCH GUIDE"
+  } else
+    return sectionHandle
+      .split(/(?=[A-Z])/)
+      .join(" ")
+      .toUpperCase()
+}
+async function setFilters() {
+
+  const filters = []
+  // Not using searchconfig here as types filter data comming from ES was not useful
+  let obj = {
+    label: config.siteSearch.filters[0].label,
+    esFieldName: config.siteSearch.filters[0].esFieldName,
+    inputType: config.siteSearch.filters[0].inputType,
+    items:
+      config.siteSearch.sectionHandleMapping.reduce(
+        (accumulator, value) => {
+          return [...accumulator, { name: value.key }]
+        },
+        []
+      ) || [],
+  }
+  console.log("getlisting obj:" + JSON.stringify(obj))
+  filters.push(obj)
+
+  searchFilters.value = filters
+}
+
+async function getSearchData(data) {
+  //const queryString = new URLSearchParams(data.filters).toString()
+  // console.log("using url search params:" + queryString)
+  try {
+    useRouter().push({
+      path: route.path,
+      query: {
+        q: data.text,
+        filters: JSON.stringify(data.filters),
+      },
+    })
+  } catch (e) {
+    throw new Error("ES error maybe: " + e)
+  }
+}
+
+</script>
+<template lang="html">
+  <main
+    id="main"
+    class="page page-search-site"
+  >
+    <masthead-secondary title="Search Results" />
+
+    <search-generic
+      :search-generic-query="searchGenericQuery"
+      placeholder="Search library website"
+      :filters="searchFilters"
+      @search-ready="getSearchData"
+    />
+
+    <section-wrapper theme="divider">
+      <divider-way-finder
+        class="search-margin"
+        color="default"
+      />
+    </section-wrapper>
+
+
+    <section-wrapper
+      v-if="isSearching"
+      class="results section-no-top-margin"
+    >
+      <div>
+        <p>...Search results loading</p>
+      </div>
+    </section-wrapper>
+    <div v-else>
+      <section-wrapper
+        v-if="page && page.hits && page.hits.hits.length > 0"
+        class="meta section-no-top-margin"
+      >
+        <h2 class="about-results">
+          Displaying {{ page.hits.total.value }} results for
+          <strong><em>“{{ route.query.q }}”</em></strong>
+        </h2>
+
+        <section-wrapper
+          v-for="(result, index) in parsedSearchResults"
+          :key="`SearchResultBlock${index}`"
+          class="section-wrapper-block"
+        >
+          <search-result
+            :title="result.title"
+            :category="parseCategory(result.sectionHandle)"
+            :summary="result.summary || result.text"
+            :to="result.to"
+            class="search-result-item"
+          />
+          <divider-general class="divider-general" />
+        </section-wrapper>
+        <section-wrapper v-if="page.hits.total.value > 10">
+          <section-pagination
+            :previous-to="parsePrev"
+            :next-to="parseNext"
+          />
+        </section-wrapper>
+      </section-wrapper>
+      <section-wrapper
+        v-else
+        class="section-no-top-margin"
+      >
+        <rich-text class="error-text">
+          <h2>Search for “{{ route.query.q }}” not found.</h2>
+          <p>
+            We can’t find the page you are looking for, but we're
+            here to help. Try these regularly visited links or one
+            of the Additional Search Tools below.
+          </p>
+          <ul>
+            <li>
+              <a href="https://library.ucla.edu">UCLA Library Home</a>
+            </li>
+            <li>
+              <a href="https://www.library.ucla.edu/research-teaching-support/research-help">Research Help</a>
+            </li>
+            <li>
+              <a href="/help/services-resources/ask-us">Ask Us</a>
+            </li>
+            <li>
+              <a href="https://www.library.ucla.edu/use/access-privileges/disability-resources">Accessibility
+                Resources</a>
+            </li>
+          </ul>
+        </rich-text>
+      </section-wrapper>
+
+      <section-wrapper>
+        <divider-way-finder class="divider-way-finder" />
+      </section-wrapper>
+
+      <section-wrapper>
+        <section-cards-with-illustrations
+          class="section-cards"
+          :items="searchAdditionalResources"
+          section-title="Additional Search Tools"
+        />
+      </section-wrapper>
+    </div>
+  </main>
+</template>
+
+<style lang="scss" scoped>
+.section-wrapper-block:last-child {
+  .divider-general {
+    display: none;
+  }
+}
+</style>

--- a/pages/search-site/index.vue
+++ b/pages/search-site/index.vue
@@ -73,7 +73,6 @@ async function searchES() {
         previous.value = false
         next.value = false
       }
-
     } else {
       noResultsFound.value = true
       page.value = {}

--- a/pages/visit/locations/[slug].vue
+++ b/pages/visit/locations/[slug].vue
@@ -36,6 +36,7 @@ if (!data.value.entry) {
 }
 if (data.value.entry.slug && process.server) {
   const { $elasticsearchplugin } = useNuxtApp()
+  console.log('Indexing location', data.value.entry.slug)
   await $elasticsearchplugin?.index(data.value.entry, data.value.entry.slug)
 }
 

--- a/plugins/indexer.server.js
+++ b/plugins/indexer.server.js
@@ -1,21 +1,20 @@
-export default defineNuxtPlugin(async (nuxtApp) => {
+export default defineNuxtPlugin((nuxtApp) => {
   // console.log("elastic search plugin index  :")
-  // const esIndex = useRuntimeConfig().public.esTempIndex
-  const esIndex = await useFetch('/api/fetchTempIndexName')
+  const esIndex = useRuntimeConfig().public.esTempIndex
   const esURL = useRuntimeConfig().public.esURL
   const esReadKey = useRuntimeConfig().public.esReadKey
   const esWriteKey = useRuntimeConfig().esWriteKey
   async function index(data, slug) {
-    // console.log('elastic search plugin index function :', esIndex.data.value)
+    // console.log('elastic search plugin index function :', esIndex)
 
     try {
-      if (process.env.NODE_ENV !== 'development' && data && slug && esIndex?.data?.value) {
+      if (process.env.NODE_ENV !== 'development' && data && slug && esIndex) {
         /* console.log(
                 "this is the elasticsearch plugin: " + JSON.stringify(data)
             ) */
-        // console.log(`Requesting URL: ${esURL}/${esIndex.data.value}/_doc/${slug}`)
+        // console.log(`Requesting URL: ${esURL}/${esIndex}/_doc/${slug}`)
         const docExists = await fetch(
-                `${esURL}/${esIndex.data.value}/_doc/${slug}`,
+                `${esURL}/${esIndex}/_doc/${slug}`,
                 {
                   headers: {
                     Authorization: `ApiKey ${esReadKey}`,
@@ -29,14 +28,14 @@ export default defineNuxtPlugin(async (nuxtApp) => {
 
         if (docExistsResponseValue && docExistsResponseValue._source) {
           console.log('GET-RESPONSE: ' + slug)
-          const updateUrl = `${esURL}/${esIndex.data.value}/_update/${slug}`
+          const updateUrl = `${esURL}/${esIndex}/_update/${slug}`
           console.log('ES update url', updateUrl)
           const postBody = {
             doc: data
           }
           console.log('postBody', JSON.stringify(postBody))
           const updateResponse = await fetch(
-                    `${esURL}/${esIndex.data.value}/_update/${slug}`,
+                    `${esURL}/${esIndex}/_update/${slug}`,
                     {
                       headers: {
                         Authorization: `ApiKey ${esWriteKey}`,
@@ -46,12 +45,12 @@ export default defineNuxtPlugin(async (nuxtApp) => {
                       body: JSON.stringify(postBody),
                     }
           )
-          console.log('Update document in ES', updateResponse)
+          // console.log('Update document in ES', updateResponse)
           const updateJson = await updateResponse.text()
-          console.log('Update in ES', updateJson)
+          // console.log('Update in ES', updateJson)
         } else {
           const response = await fetch(
-                    `${esURL}/${esIndex.data.value}/_doc/${slug}`,
+                    `${esURL}/${esIndex}/_doc/${slug}`,
                     {
                       headers: {
                         Authorization: `ApiKey ${esWriteKey}`,
@@ -62,7 +61,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
                     }
           )
 
-          // console.log("Create a new document in ES:", await response.text())
+          console.log('Create a new document in ES:', await response.text())
         }
       } else {
         console.warn('not indexing anything')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,8 +62,8 @@ devDependencies:
     specifier: ^5.8.0
     version: 5.9.1
   ucla-library-website-components:
-    specifier: 2.39.0-alpha.76
-    version: 2.39.0-alpha.76(typescript@5.4.3)(vue-router@4.3.0)(vue@3.4.21)
+    specifier: 2.39.0-alpha.77
+    version: 2.39.0-alpha.77(typescript@5.4.3)(vue-router@4.3.0)(vue@3.4.21)
 
 packages:
 
@@ -9256,8 +9256,8 @@ packages:
     resolution: {integrity: sha512-1yoZOhiy93kHAGHyJnnmgj7eESGENUUTbXHaUsKHkFLNS9qw8Ajp4H8ppMuxkZMs/LnYBlibngZGsQC8w/vtlQ==}
     dev: true
 
-  /ucla-library-website-components@2.39.0-alpha.76(typescript@5.4.3)(vue-router@4.3.0)(vue@3.4.21):
-    resolution: {integrity: sha512-rqFKH9MfzdHQpl3vvS9EkH58thrODAKO6T+qQql1RfVRqizR9w7JmtgdkeKiIPo0GCjLoeXAXTL7h5bkxO6zJg==}
+  /ucla-library-website-components@2.39.0-alpha.77(typescript@5.4.3)(vue-router@4.3.0)(vue@3.4.21):
+    resolution: {integrity: sha512-ezpV2BTEWxWM/dY5OYoTdKrn5/qxFVSzkOu8GNVGrb8frDbuTrJiVIg0wzKM6i2m5rykPDej952eCLpnAnAMrw==}
     peerDependencies:
       vue: ^3.4
       vue-router: ^4.2.4

--- a/server/api/fetchTempIndexName.js
+++ b/server/api/fetchTempIndexName.js
@@ -1,6 +1,0 @@
-export default cachedEventHandler(async () => {
-  // console.log("cachedEventHandler fetchTemIndexName",useStorage("esData"))
-  const response = await useStorage('esData').hasItem('tempIndex')
-  console.log('cachedEventHandler fetchTemIndexName hasItem result', response, await useStorage('esData').getItem('tempIndex'))
-  return await useStorage('esData').getItem('tempIndex')
-})


### PR DESCRIPTION
Connected to [APPS-2662](https://jira.library.ucla.edu/browse/APPS-2662)

**Page/Pages Created/updated:** /search-site/index.vue 

**Notes:**

There is a bug in the search-home component, https://uclalibrary.atlassian.net/browse/APPS-2668, which will be fixed first before we merge this.

**Time Report:**

This took me 2 hours to build this. But I had to fix an `insert before` error on the static page and I also found out that tests were failing as useStorage which was storing the temp index was not reliable. So I simplified it to create the temp index name in Nuxt config, removed it from init.js, and cleaned up some unwanted code

**Checklist:**

-   [x] I added github label for semantic versioning
-   [x] I double checked it looks like the designs
-   [ ] I completed any required mobile breakpoint styling
-   [ ] I completed any required hover state styling
-   [x] I included a working spec file
-   [x] I added notes above about how long it took to build this component
-   [ ] UX has reviewed this PR
-   [x] I assigned this PR to someone to review


[APPS-2662]: https://uclalibrary.atlassian.net/browse/APPS-2662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ