### PR TITLE
fix: APPS-2664 Remove query portion that is not required

### DIFF
--- a/gql/fragments/BlockImpactNumberCardsFragment.gql
+++ b/gql/fragments/BlockImpactNumberCardsFragment.gql
@@ -11,18 +11,4 @@ fragment BlockImpactNumberCardsFragment on ElementInterface {
             impactNumber
         }
     }
-    ... on impactReportFpb_impactNumberCards_BlockType {
-        id
-        typehandle
-        sectionSummary: summary
-        sectionTitle: titleGeneral
-        impactNumberCards {
-            ... on impactNumberCards_impactNumberCard_BlockType {
-                id
-                title: titleGeneral
-                text: description
-                impactNumber
-            }
-        }
-    }
 }


### PR DESCRIPTION
Connected to [APPS-2664](https://jira.library.ucla.edu/browse/APPS-2664)

**Page/Pages Created/updated:** gql/fragments/BlockImpactNumberCardsFragment.gql from #APPS-2664

**Notes:**

Removed an extra query from BlockImpactNumberCardsFragment.gql 

**Time Report:**

This took me 45ish minutes to edit and test.

**Checklist:**

-   [ X] I added github label for semantic versioning
-   [ ] I double checked it looks like the designs
-   [ ] I completed any required mobile breakpoint styling
-   [ ] I completed any required hover state styling
-   [ ] I included a working spec file
-   [ X] I added notes above about how long it took to build this component
-   [ ] UX has reviewed this PR
-   [ ] I assigned this PR to someone to review


[APPS-2664]: https://uclalibrary.atlassian.net/browse/APPS-2664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ