### PR TITLE
feat: APPS-2658   Migrate collections/explore index page template to nuxt3

### DIFF
--- a/cypress/e2e/collectionsexplorepage.cy.js
+++ b/cypress/e2e/collectionsexplorepage.cy.js
@@ -18,9 +18,23 @@ describe('Explore Collection page', () => {
     cy.percySnapshot({ widths: [768, 992, 1200] })
   })
 
-  it('Visit Collections Explore Listing page filter by category', () => {
-    cy.visit('/collections/explore?q=&filters=%7B"subjectAreas.title.keyword"%3A%5B"Arts%20%26%20Music"%5D%7D')
-
-    cy.get('h2.about-results').should('be.visible')
+  it('Search Found', () => {
+    cy.intercept('/collections/explore/?*').as('getExploreSearchRoutes')
+    cy.visit('collections/explore/?q=test', { timeout: 35000 })
+    cy.wait('@getExploreSearchRoutes').then(() => {
+      cy.get('.logo-ucla').should('be.visible')
+      cy.get('input[type=search]').should(
+        'have.value',
+        'test'
+      )
+      cy.get('h2.about-results').invoke('text').should('not.be.empty')
+      cy.percySnapshot({ widths: [768, 992, 1200] })
+    })
   })
+
+    it("Visit Collections Explore Listing page filter by category", () => {
+        cy.visit('/collections/explore?q=&filters=%7B"subjectAreas.title.keyword"%3A%5B"Arts%20%26%20Music"%5D%7D')
+
+        cy.get ('h2.about-results').should("be.visible")
+    })
 })

--- a/cypress/e2e/collectionsexplorepage.cy.js
+++ b/cypress/e2e/collectionsexplorepage.cy.js
@@ -1,26 +1,26 @@
-describe("Explore Collection page", () => {
-    it("Visit a Explore Collection Page", () => {
-        cy.visit("/collections/explore")
+describe('Explore Collection page', () => {
+  it('Visit a Explore Collection Page', () => {
+    cy.visit('/collections/explore')
 
-        // UCLA Library brand
-        cy.get(".logo-ucla").should("be.visible")
-        cy.get(".page-collections-explore").should("be.visible")
-        cy.get("h1.title").should(
-            "contain",
-            "Listing - Collections > Explore Collections"
-        )
-        // cy.get('.search-generic-filter-buttons').find('button').should('have.length', 2)
-        // // eslint-disable-next-line no-unused-vars
-        // cy.get('.search-generic-filter-buttons').find('button').each(($el, index, $list) => {
-        //     cy.wrap($el).click()
-        //     cy.get("fieldset.base-checkbox-group > ul.list > li.list-item").find("label").should("have.length.greaterThan",0)
-        // })
-        cy.percySnapshot({ widths: [768, 992, 1200] })
-    })
-
-    // it("Visit Collections Explore Listing page filter by category", () => {
-    //     cy.visit('/collections/explore?q=&filters=%7B"subjectAreas.title.keyword"%3A%5B"Arts%20%26%20Music"%5D%7D')
-
-    //     cy.get ('h2.about-results').should("be.visible")
+    // UCLA Library brand
+    cy.get('.logo-ucla').should('be.visible')
+    cy.get('.page-collections-explore').should('be.visible')
+    cy.get('h1.title').should(
+      'contain',
+      'Listing - Collections > Explore Collections'
+    )
+    // cy.get('.search-generic-filter-buttons').find('button').should('have.length', 2)
+    // // eslint-disable-next-line no-unused-vars
+    // cy.get('.search-generic-filter-buttons').find('button').each(($el, index, $list) => {
+    //     cy.wrap($el).click()
+    //     cy.get("fieldset.base-checkbox-group > ul.list > li.list-item").find("label").should("have.length.greaterThan",0)
     // })
+    cy.percySnapshot({ widths: [768, 992, 1200] })
+  })
+
+  // it("Visit Collections Explore Listing page filter by category", () => {
+  //     cy.visit('/collections/explore?q=&filters=%7B"subjectAreas.title.keyword"%3A%5B"Arts%20%26%20Music"%5D%7D')
+
+  //     cy.get ('h2.about-results').should("be.visible")
+  // })
 })

--- a/cypress/e2e/collectionsexplorepage.cy.js
+++ b/cypress/e2e/collectionsexplorepage.cy.js
@@ -9,18 +9,18 @@ describe('Explore Collection page', () => {
       'contain',
       'Listing - Collections > Explore Collections'
     )
-    // cy.get('.search-generic-filter-buttons').find('button').should('have.length', 2)
-    // // eslint-disable-next-line no-unused-vars
-    // cy.get('.search-generic-filter-buttons').find('button').each(($el, index, $list) => {
-    //     cy.wrap($el).click()
-    //     cy.get("fieldset.base-checkbox-group > ul.list > li.list-item").find("label").should("have.length.greaterThan",0)
-    // })
+    cy.get('.search-generic-filter-buttons').find('button').should('have.length', 2)
+
+    cy.get('.search-generic-filter-buttons').find('button').each(($el, index, $list) => {
+      cy.wrap($el).click()
+      cy.get('fieldset.base-checkbox-group > ul.list > li.list-item').find('label').should('have.length.greaterThan', 0)
+    })
     cy.percySnapshot({ widths: [768, 992, 1200] })
   })
 
-  // it("Visit Collections Explore Listing page filter by category", () => {
-  //     cy.visit('/collections/explore?q=&filters=%7B"subjectAreas.title.keyword"%3A%5B"Arts%20%26%20Music"%5D%7D')
+  it('Visit Collections Explore Listing page filter by category', () => {
+    cy.visit('/collections/explore?q=&filters=%7B"subjectAreas.title.keyword"%3A%5B"Arts%20%26%20Music"%5D%7D')
 
-  //     cy.get ('h2.about-results').should("be.visible")
-  // })
+    cy.get('h2.about-results').should('be.visible')
+  })
 })

--- a/cypress/e2e/collectionsexplorepage.cy.js
+++ b/cypress/e2e/collectionsexplorepage.cy.js
@@ -32,9 +32,9 @@ describe('Explore Collection page', () => {
     })
   })
 
-    it("Visit Collections Explore Listing page filter by category", () => {
-        cy.visit('/collections/explore?q=&filters=%7B"subjectAreas.title.keyword"%3A%5B"Arts%20%26%20Music"%5D%7D')
+  it('Visit Collections Explore Listing page filter by category', () => {
+    cy.visit('/collections/explore?q=&filters=%7B"subjectAreas.title.keyword"%3A%5B"Arts%20%26%20Music"%5D%7D')
 
-        cy.get ('h2.about-results').should("be.visible")
-    })
+    cy.get('h2.about-results').should('be.visible')
+  })
 })

--- a/cypress/e2e/collectionsexplorepage.cy.js
+++ b/cypress/e2e/collectionsexplorepage.cy.js
@@ -1,0 +1,26 @@
+describe("Explore Collection page", () => {
+    it("Visit a Explore Collection Page", () => {
+        cy.visit("/collections/explore")
+
+        // UCLA Library brand
+        cy.get(".logo-ucla").should("be.visible")
+        cy.get(".page-collections-explore").should("be.visible")
+        cy.get("h1.title").should(
+            "contain",
+            "Listing - Collections > Explore Collections"
+        )
+        // cy.get('.search-generic-filter-buttons').find('button').should('have.length', 2)
+        // // eslint-disable-next-line no-unused-vars
+        // cy.get('.search-generic-filter-buttons').find('button').each(($el, index, $list) => {
+        //     cy.wrap($el).click()
+        //     cy.get("fieldset.base-checkbox-group > ul.list > li.list-item").find("label").should("have.length.greaterThan",0)
+        // })
+        cy.percySnapshot({ widths: [768, 992, 1200] })
+    })
+
+    // it("Visit Collections Explore Listing page filter by category", () => {
+    //     cy.visit('/collections/explore?q=&filters=%7B"subjectAreas.title.keyword"%3A%5B"Arts%20%26%20Music"%5D%7D')
+
+    //     cy.get ('h2.about-results').should("be.visible")
+    // })
+})

--- a/gql/fragments/BlockAssociatedTopicCardsFragment.gql
+++ b/gql/fragments/BlockAssociatedTopicCardsFragment.gql
@@ -13,6 +13,7 @@ fragment BlockAssociatedTopicCardsFragment on ElementInterface {
                 uri
                 text: summary
                 uri
+                iconName: illustrationsResourcesAndServices
             }
         }
     }

--- a/pages/about/news/index.vue
+++ b/pages/about/news/index.vue
@@ -16,8 +16,7 @@ const { $graphql, $dataApi } = useNuxtApp()
 const { data, error } = await useAsyncData('news', async () => {
   const data = await $graphql.default.request(ARTICLE_LIST)
   return data
-}
-)
+})
 
 if (error.value) {
   throw createError({
@@ -33,15 +32,18 @@ if (!data.value.entry && !data.value.entries) {
 
 const route = useRoute()
 
-// Data
+// DATA
 const page = ref(_get(data.value, 'entry', {}))
 const news = ref(_get(data.value, 'entries', []))
+
+// PREVIEW MODE
 watch(data, (newVal, oldVal) => {
   console.log('In watch preview enabled, newVal, oldVal', newVal, oldVal)
   page.value = _get(newVal, 'entry', {})
   news.value = _get(newVal, 'entries', [])
 })
 
+// HEAD METADATA FOR THE TAB TITLES ON THE PAGE
 useHead({
   title: page.value ? page.value.title : '... loading',
   meta: [
@@ -53,6 +55,7 @@ useHead({
   ]
 })
 
+// COMPUTED
 const parsedFeaturedNews = computed(() => {
   return page.value?.featuredNews?.map((obj) => {
     return {
@@ -127,7 +130,7 @@ const parsedByline = computed(() => {
   })
 })
 
-// ES search functionality
+// ELASTIC SEARCH FUNCTIONALITY
 const hits = ref([])
 const title = ref('')
 const noResultsFound = ref(false)
@@ -140,7 +143,7 @@ const searchGenericQuery = ref({
     {},
 })
 
-// This watcher is called when router push updates the query params
+// This watcher is called when router pushes updates the query params
 watch(
   () => route.query,
   (newVal, oldVal) => {
@@ -229,7 +232,7 @@ function parseHits(hits = []) {
   })
 }
 
-//  This is event handler which is invoked by search-generic component selections
+// This is event handler which is invoked by search-generic component selections
 function getSearchData(data) {
   console.log('On the page getsearchdata called')
   useRouter().push({
@@ -294,7 +297,7 @@ onMounted(async () => {
         page.featuredNews.length > 0 &&
         hits.length === 0 &&
         !noResultsFound
-      "
+        "
       class="section-no-top-margin"
     >
       <banner-featured
@@ -310,14 +313,12 @@ onMounted(async () => {
         class="banner section-featured-banner"
       />
 
-      <divider-general
-        v-show="page &&
-          page.featuredNews &&
-          page.featuredNews.length &&
-          hits.length === 0 &&
-          !noResultsFound
-        "
-      />
+      <divider-general v-show="page &&
+        page.featuredNews &&
+        page.featuredNews.length &&
+        hits.length === 0 &&
+        !noResultsFound
+        " />
 
       <section-teaser-highlight
         v-show="parsedSectionHighlight.length > 0"
@@ -332,7 +333,7 @@ onMounted(async () => {
         page.featuredNews.length > 0 &&
         hits.length === 0 &&
         !noResultsFound
-      "
+        "
       theme="divider"
     >
       <divider-way-finder color="about" />
@@ -414,6 +415,9 @@ onMounted(async () => {
   </main>
 </template>
 
-<style lang="scss" scoped>
+<style
+  lang="scss"
+  scoped
+>
 .page-news {}
 </style>

--- a/pages/about/news/index.vue
+++ b/pages/about/news/index.vue
@@ -297,7 +297,7 @@ onMounted(async () => {
         page.featuredNews.length > 0 &&
         hits.length === 0 &&
         !noResultsFound
-        "
+      "
       class="section-no-top-margin"
     >
       <banner-featured
@@ -313,12 +313,14 @@ onMounted(async () => {
         class="banner section-featured-banner"
       />
 
-      <divider-general v-show="page &&
-        page.featuredNews &&
-        page.featuredNews.length &&
-        hits.length === 0 &&
-        !noResultsFound
-        " />
+      <divider-general
+        v-show="page &&
+          page.featuredNews &&
+          page.featuredNews.length &&
+          hits.length === 0 &&
+          !noResultsFound
+        "
+      />
 
       <section-teaser-highlight
         v-show="parsedSectionHighlight.length > 0"
@@ -333,7 +335,7 @@ onMounted(async () => {
         page.featuredNews.length > 0 &&
         hits.length === 0 &&
         !noResultsFound
-        "
+      "
       theme="divider"
     >
       <divider-way-finder color="about" />

--- a/pages/about/news/index.vue
+++ b/pages/about/news/index.vue
@@ -154,6 +154,7 @@ watch(
   }, { deep: true, immediate: true }
 )
 
+// ELASTIC SEARCH FUNCTION
 async function searchES() {
   if (
     (route.query.q && route.query.q !== '') ||

--- a/pages/collections/access/index.vue
+++ b/pages/collections/access/index.vue
@@ -186,6 +186,7 @@ function getSearchData(data) {
   })
 }
 </script>
+
 <template lang="html">
   <main
     id="main"
@@ -217,7 +218,7 @@ function getSearchData(data) {
       <divider-way-finder class="search-margin" />
     </section-wrapper>
     <section-wrapper v-show="page && page.accessCollections && hits.length == 0 && !noResultsFound
-      ">
+        ">
       <section-cards-with-illustrations
         class="section"
         :items="parsedAccessCollections"
@@ -290,4 +291,8 @@ function getSearchData(data) {
     </section-wrapper>
   </main>
 </template>
-<style lang="scss" scoped></style>
+
+<style
+  lang="scss"
+  scoped
+></style>

--- a/pages/collections/access/index.vue
+++ b/pages/collections/access/index.vue
@@ -217,8 +217,10 @@ function getSearchData(data) {
     <section-wrapper theme="divider">
       <divider-way-finder class="search-margin" />
     </section-wrapper>
-    <section-wrapper v-show="page && page.accessCollections && hits.length == 0 && !noResultsFound
-        ">
+    <section-wrapper
+      v-show="page && page.accessCollections && hits.length == 0 && !noResultsFound
+      "
+    >
       <section-cards-with-illustrations
         class="section"
         :items="parsedAccessCollections"

--- a/pages/collections/access/index.vue
+++ b/pages/collections/access/index.vue
@@ -54,8 +54,6 @@ if (
 const page = ref(_get(data.value, 'entry', {}))
 // console.log('In page', page.value)
 
-// TODO another watcher? when does this fire?
-// TODO was data
 watch(data, (newVal, oldVal) => {
   console.log('In watch preview enabled', newVal, oldVal)
   page.value = _get(newVal, 'entry', {})
@@ -217,10 +215,8 @@ function getSearchData(data) {
     <section-wrapper theme="divider">
       <divider-way-finder class="search-margin" />
     </section-wrapper>
-    <section-wrapper
-      v-show="page && page.accessCollections && hits.length == 0 && !noResultsFound
-      "
-    >
+    <section-wrapper v-show="page && page.accessCollections && hits.length == 0 && !noResultsFound
+        ">
       <section-cards-with-illustrations
         class="section"
         :items="parsedAccessCollections"

--- a/pages/collections/access/index.vue
+++ b/pages/collections/access/index.vue
@@ -226,7 +226,7 @@ function getSearchData(data) {
         :is-horizontal="true"
       />
     </section-wrapper>
-    
+
     <section-wrapper v-show="hits && hits.length > 0">
       <h2
         v-if="route.query && route.query.q"

--- a/pages/collections/explore/index.vue
+++ b/pages/collections/explore/index.vue
@@ -78,15 +78,15 @@ async function searchES() {
       const data = await $graphql.default.request(
         COLLECTIONS_EXPLORE_LIST
       )
-      page["title"] = _get(data, "entry.title", "")
-      page["text"] = _get(data, "entry.text", "")
+      page.title = _get(data, 'entry.title', '')
+      page.text = _get(data, 'entry.text', '')
     }
 
-    const query_text = route.query.q || "*"
+    const query_text = route.query.q || '*'
     const results = await $dataApi.keywordSearchWithFilters(
       query_text,
       config.exploreCollection.searchFields,
-      "sectionHandle:collection",
+      'sectionHandle:collection',
       (route.query.filters &&
         JSON.parse(route.query.filters)) ||
       {},
@@ -95,7 +95,7 @@ async function searchES() {
       config.exploreCollection.resultFields,
       config.exploreCollection.filters
     )
-    //console.log("getsearchdata method:" + JSON.stringify(results))
+    // console.log("getsearchdata method:" + JSON.stringify(results))
     collections.value = []
     hits.value = []
     if (results && results.hits && results.hits.total.value > 0) {
@@ -108,7 +108,7 @@ async function searchES() {
       noResultsFound.value = true
     }
     searchGenericQuery = {
-      queryText: route.query.q || "",
+      queryText: route.query.q || '',
       queryFilters:
         ($route.query.filters &&
           JSON.parse(route.query.filters)) ||
@@ -122,8 +122,8 @@ async function searchES() {
       COLLECTIONS_EXPLORE_LIST
     )
     // //console.log("data:" + data)
-    page.value = _get(data, "entry", {})
-    collections.value = _get(data, "entries", [])
+    page.value = _get(data, 'entry', {})
+    collections.value = _get(data, 'entries', [])
   }
 }
 // ES watcher
@@ -189,9 +189,6 @@ const parsedPlaceholder = computed(() => {
 const parseHitsResults = computed(() => {
   return parseHits(hits)
 })
-
-
-
 
 /* TODO: Incorporate when search functionality is ready? */
 // Watch route for new queries
@@ -273,7 +270,6 @@ const parseHitsResults = computed(() => {
     id="main"
     class="page page-collections-explore"
   >
-
     <!-- <h3>DATA: {{ data }}</h3>
     <h3>PAGE: {{ page }}</h3> -->
     <!-- <h3>COLLECTIONS: {{ collections }}</h3> -->
@@ -315,14 +311,12 @@ const parseHitsResults = computed(() => {
       <divider-way-finder class="search-margin" />
     </section-wrapper>
 
-
-
     <section-wrapper
       v-show="page &&
-      parsedCollectionList &&
-      parsedCollectionList.length &&
-      hits.length == 0 &&
-      !noResultsFound
+        parsedCollectionList &&
+        parsedCollectionList.length &&
+        hits.length == 0 &&
+        !noResultsFound
       "
       class="section-no-top-margin"
     >

--- a/pages/collections/explore/index.vue
+++ b/pages/collections/explore/index.vue
@@ -6,7 +6,7 @@ import _get from 'lodash/get'
 import removeTags from '../utils/removeTags'
 
 // GQL
-import EXPLORE_COLLECTIONS from '../gql/queries/CollectionsExploreList.gql'
+import COLLECTIONS_EXPLORE_LIST from '../gql/queries/CollectionsExploreList.gql'
 
 // ELASTIC SEARCH UTILITIES
 // import getListingFilters from '../utils/getListingFilters'
@@ -24,7 +24,7 @@ definePageMeta({
 })
 
 // ASYNC DATA
-const { data: page, error } = await useAsyncData('collection', async () => {
+const { data, error } = await useAsyncData('collection', async () => {
   const data = await $graphql.default.request(COLLECTIONS_EXPLORE_LIST)
   return data
 })
@@ -48,6 +48,14 @@ const searchGenericQuery = ref({
   queryText: route.query.q || '',
 })
 
+// PREVIEW MODE
+watch(data, (newVal, oldVal) => {
+  console.log('In watch preview enabled, newVal, oldVal', newVal, oldVal)
+  page.value = _get(newVal, 'entry', {})
+  collections.value = _get(newVal, 'entries', [])
+})
+
+
 // TODO: change these into constants
 // data() {
 //   return {
@@ -70,6 +78,10 @@ const searchGenericQuery = ref({
 
 
 /* TODO: Refactor when search functionality is ready */
+// BECOME THE ESSEARCH FUNCTION
+// async function searchES() {
+
+
 // async fetch() {
 // this.collections = []
 // this.hits = []
@@ -133,6 +145,13 @@ const searchGenericQuery = ref({
 // }
 // }
 
+
+// ENABLE PREVIEW MODE
+watch(data, (newVal, oldVal) => {
+  console.log('In watch preview enabled', newVal, oldVal)
+  page.value = _get(newVal, 'entry', {})
+})
+
 // HEAD
 
 useHead({
@@ -163,7 +182,7 @@ const parsedCollectionList = computed(() => {
 })
 
 const parsedAssociatedTopics = computed(() => {
-  return this.page.associatedTopics.map((obj) => {
+  return page.value.associatedTopics.map((obj) => {
     return {
       ...obj,
       to: obj.externalResourceUrl
@@ -182,8 +201,8 @@ const parsedAssociatedTopics = computed(() => {
 //   return this.parseHits(this.hits)
 // })
 
-// METHODS
-// ENABLE PREVIEW MODE
+
+
 
 /* TODO: Incorporate when search functionality is ready? */
 // Watch route for new queries
@@ -265,8 +284,8 @@ const parsedAssociatedTopics = computed(() => {
     id="main"
     class="page page-collections-explore"
   >
-    HELLO from the Collections index page<br> 🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅
-    <!-- <nav-breadcrumb
+
+    <nav-breadcrumb
       to="/collections"
       title="Explore Featured Collections"
       parent-title="Collections"
@@ -275,35 +294,23 @@ const parsedAssociatedTopics = computed(() => {
     <masthead-secondary
       :title="page.title"
       :text="page.summary"
-    /> -->
+    />
 
-    <!-- SEARCH
-                Filters by physical/digital & subject area -->
-    <!-- <search-generic
+    <!-- SEARCH Filters by physical/digital & subject area -->
+    <search-generic
       search-type="about"
       :filters="searchFilters"
       class="generic-search"
       :search-generic-query="searchGenericQuery"
       :placeholder="parsedPlaceholder"
       @search-ready="getSearchData"
-    /> -->
+    />
 
-    <!-- <section-wrapper theme="divider">
+    <section-wrapper theme="divider">
       <divider-way-finder class="search-margin" />
-    </section-wrapper> -->
+    </section-wrapper>
 
-    <!-- DELETE AT THE END -->
-    <!-- <h3> {{ parsedCollectionList }}</h3>
-    <hr>
-    <h3>{{ parsedAssociatedTopics }}</h3>
-    <hr>
-    <h3> {{ parsedPlaceholder }}</h3>
-    <hr>
-    <h3>{{ parseHitsResults }}</h3>
-    <hr>
-    <h3>{{ `On the page getsearchdata called ${data}` }}</h3> -->
-
-    <!-- <section-wrapper
+    <section-wrapper
       v-show="page &&
         parsedCollectionList &&
         parsedCollectionList.length &&
@@ -313,10 +320,10 @@ const parsedAssociatedTopics = computed(() => {
       class="section-no-top-margin"
     >
       <section-teaser-card :items="parsedCollectionList" />
-    </section-wrapper> -->
+    </section-wrapper>
 
     <!-- FILTERS -->
-    <!-- <section-wrapper
+    <section-wrapper
       v-show="hits && hits.length > 0"
       class="section-no-top-margin"
     >
@@ -335,10 +342,10 @@ const parsedAssociatedTopics = computed(() => {
         Displaying {{ hits.length }} results
       </h2>
       <section-teaser-card :items="parseHitsResults" />
-    </section-wrapper> -->
+    </section-wrapper>
 
     <!-- NO RESULTS -->
-    <!-- <section-wrapper
+    <section-wrapper
       v-show="noResultsFound"
       class="section-no-top-margin"
     >
@@ -366,16 +373,16 @@ const parsedAssociatedTopics = computed(() => {
           </ul>
         </rich-text>
       </div>
-    </section-wrapper> -->
+    </section-wrapper>
 
-    <!-- <section-wrapper>
+    <section-wrapper>
       <divider-way-finder
         class="divider-way-finder"
         color="default"
       />
-    </section-wrapper> -->
+    </section-wrapper>
 
-    <!-- <section-wrapper>
+    <section-wrapper>
       <section-cards-with-illustrations
         class="section"
         :items="parsedAssociatedTopics"
@@ -383,7 +390,7 @@ const parsedAssociatedTopics = computed(() => {
         to="/help/services-resources"
         section-title="Associated Topics"
       />
-    </section-wrapper> -->
+    </section-wrapper>
   </main>
 </template>
 

--- a/pages/collections/explore/index.vue
+++ b/pages/collections/explore/index.vue
@@ -259,6 +259,7 @@ const parsedAssociatedTopics = computed(() => {
     id="main"
     class="page page-collections-explore"
   >
+    HELLO from the Collections index page<br> 🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅
     <!-- <nav-breadcrumb
       to="/collections"
       title="Explore Featured Collections"
@@ -286,7 +287,7 @@ const parsedAssociatedTopics = computed(() => {
     </section-wrapper> -->
 
     <!-- DELETE AT THE END -->
-    <h3> {{ parsedCollectionList }}</h3>
+    <!-- <h3> {{ parsedCollectionList }}</h3>
     <hr>
     <h3>{{ parsedAssociatedTopics }}</h3>
     <hr>
@@ -294,7 +295,7 @@ const parsedAssociatedTopics = computed(() => {
     <hr>
     <h3>{{ parseHitsResults }}</h3>
     <hr>
-    <h3>{{ `On the page getsearchdata called ${data}` }}</h3>
+    <h3>{{ `On the page getsearchdata called ${data}` }}</h3> -->
 
     <!-- <section-wrapper
       v-show="page &&

--- a/pages/collections/explore/index.vue
+++ b/pages/collections/explore/index.vue
@@ -90,7 +90,6 @@ const parsedAssociatedTopics = computed(() => {
   })
 })
 
-
 // ELASTIC SEARCH FUNCTIONALITY
 const hits = ref([])
 const noResultsFound = ref(false)
@@ -148,7 +147,7 @@ async function searchES() {
       config.exploreCollection.resultFields,
       config.exploreCollection.filters
     )
-    console.log("getsearchdata method:" + JSON.stringify(results))
+    console.log('getsearchdata method:' + JSON.stringify(results))
     collections.value = []
     hits.value = []
     if (results && results.hits && results.hits.total.value > 0) {
@@ -187,12 +186,12 @@ const parsedPlaceholder = computed(() => {
 const parseHitsResults = computed(() => {
   return hits.value.map((obj) => {
     return {
-      ...obj["_source"],
-      to: obj["_source"].externalResourceUrl
-        ? obj["_source"].externalResourceUrl
-        : `/${obj["_source"].uri}`,
-      image: _get(obj["_source"], "heroImage[0]image[0]", null),
-      category: obj["_source"].physicalDigital.join(", "),
+      ...obj._source,
+      to: obj._source.externalResourceUrl
+        ? obj._source.externalResourceUrl
+        : `/${obj._source.uri}`,
+      image: _get(obj._source, 'heroImage[0]image[0]', null),
+      category: obj._source.physicalDigital.join(', '),
     }
   })
 })
@@ -205,7 +204,7 @@ function getSearchData(data) {
   console.log('data text', data.text)
   console.log('data filters', JSON.stringify(data.filters))
   useRouter().push({
-    path: "/collections/explore",
+    path: '/collections/explore',
     query: {
       q: data.text,
       filters: JSON.stringify(data.filters),
@@ -217,11 +216,11 @@ function getSearchData(data) {
 async function setFilters() {
   const searchAggsResponse = await $dataApi.getAggregations(
     config.exploreCollection.filters,
-    "collection"
+    'collection'
   )
-  /*console.log(
+  /* console.log(
       "Search Aggs Response: " + JSON.stringify(searchAggsResponse)
-  )*/
+  ) */
   searchFilters.value = getListingFilters(
     searchAggsResponse,
     config.exploreCollection.filters
@@ -247,8 +246,6 @@ onMounted(async () => {
     <h3>PAGE: {{ page }}</h3>
     <h3>COLLECTIONS: {{ collections }}</h3>
     -->
-
-
 
     <!-- <h3>parseHitsResults -- {{ parseHitsResults }}</h3> -->
     <!-- <hr>
@@ -286,7 +283,7 @@ onMounted(async () => {
         parsedCollectionList.length &&
         hits.length == 0 &&
         !noResultsFound
-        "
+      "
       class="section-no-top-margin"
     >
       <section-teaser-card :items="parsedCollectionList" />

--- a/pages/collections/explore/index.vue
+++ b/pages/collections/explore/index.vue
@@ -104,10 +104,10 @@ const searchGenericQuery = ref({
 
 // This watcher is called when router pushes updates the query params
 watch(
-  () => route.query,
+  () => route?.query,
   (newVal, oldVal) => {
     console.log('ES newVal, oldVal', newVal, oldVal)
-    searchGenericQuery.value.queryText = route.query.q || ''
+    searchGenericQuery.value.queryText = route?.query.q || ''
     searchGenericQuery.value.queryFilters = (route.query.filters && JSON.parse(route.query.filters)) || {}
     searchES()
   }, { deep: true, immediate: true }
@@ -116,7 +116,7 @@ watch(
 // ELASTIC SEARCH FUNCTION
 async function searchES() {
   if (
-    (route.query.q && route.query.q !== '') ||
+    (route?.query.q && route?.query.q !== '') ||
     (route.query.filters &&
       queryFilterHasValues(
         route.query.filters,
@@ -244,7 +244,7 @@ onMounted(async () => {
         parsedCollectionList.length &&
         hits.length == 0 &&
         !noResultsFound
-      "
+        "
       class="section-no-top-margin"
     >
       <section-teaser-card :items="parsedCollectionList" />

--- a/pages/collections/explore/index.vue
+++ b/pages/collections/explore/index.vue
@@ -84,7 +84,7 @@ async function searchES() {
 
     const query_text = route.query.q || '*'
     const results = await $dataApi.keywordSearchWithFilters(
-      query_text,
+      queryText,
       config.exploreCollection.searchFields,
       'sectionHandle:collection',
       (route.query.filters &&
@@ -313,10 +313,10 @@ const parseHitsResults = computed(() => {
 
     <section-wrapper
       v-show="page &&
-        parsedCollectionList &&
-        parsedCollectionList.length &&
-        hits.length == 0 &&
-        !noResultsFound
+      parsedCollectionList &&
+      parsedCollectionList.length &&
+      hits.length == 0 &&
+      !noResultsFound
       "
       class="section-no-top-margin"
     >

--- a/pages/collections/explore/index.vue
+++ b/pages/collections/explore/index.vue
@@ -284,6 +284,21 @@ const parsedAssociatedTopics = computed(() => {
     id="main"
     class="page page-collections-explore"
   >
+    HELLO from the Collections index page<br> 🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅🐅
+    <!-- <h3>DATA: {{ data }}</h3>
+    <h3>PAGE: {{ page }}</h3> -->
+    <h3>COLLECTIONS: {{ collections }}</h3>
+
+    <!-- DELETE AT THE END -->
+    <h3> parsedCollectionList -- {{ parsedCollectionList }}</h3>
+    <hr>
+    <h3>parsedAssociatedTopics -- {{ parsedAssociatedTopics }}</h3>
+    <hr>
+    <h3>parsedPlaceholder -- {{ parsedPlaceholder }}</h3>
+    <hr>
+    <h3>parseHitsResults -- {{ parseHitsResults }}</h3>
+    <hr>
+    <h3>data: {{ `On the page getsearchdata called ${data}` }}</h3>
 
     <nav-breadcrumb
       to="/collections"
@@ -296,34 +311,37 @@ const parsedAssociatedTopics = computed(() => {
       :text="page.summary"
     />
 
-    <!-- SEARCH Filters by physical/digital & subject area -->
-    <search-generic
+    <!-- SEARCH
+                Filters by physical/digital & subject area -->
+    <!-- <search-generic
       search-type="about"
       :filters="searchFilters"
       class="generic-search"
       :search-generic-query="searchGenericQuery"
       :placeholder="parsedPlaceholder"
       @search-ready="getSearchData"
-    />
+    /> -->
 
     <section-wrapper theme="divider">
       <divider-way-finder class="search-margin" />
     </section-wrapper>
 
+
+
     <section-wrapper
       v-show="page &&
-        parsedCollectionList &&
-        parsedCollectionList.length &&
-        hits.length == 0 &&
-        !noResultsFound
-        "
+      parsedCollectionList &&
+      parsedCollectionList.length &&
+      hits.length == 0 &&
+      !noResultsFound
+      "
       class="section-no-top-margin"
     >
       <section-teaser-card :items="parsedCollectionList" />
     </section-wrapper>
 
     <!-- FILTERS -->
-    <section-wrapper
+    <!-- <section-wrapper
       v-show="hits && hits.length > 0"
       class="section-no-top-margin"
     >
@@ -342,10 +360,10 @@ const parsedAssociatedTopics = computed(() => {
         Displaying {{ hits.length }} results
       </h2>
       <section-teaser-card :items="parseHitsResults" />
-    </section-wrapper>
+    </section-wrapper> -->
 
     <!-- NO RESULTS -->
-    <section-wrapper
+    <!-- <section-wrapper
       v-show="noResultsFound"
       class="section-no-top-margin"
     >
@@ -373,7 +391,7 @@ const parsedAssociatedTopics = computed(() => {
           </ul>
         </rich-text>
       </div>
-    </section-wrapper>
+    </section-wrapper> -->
 
     <section-wrapper>
       <divider-way-finder

--- a/pages/collections/explore/index.vue
+++ b/pages/collections/explore/index.vue
@@ -113,10 +113,8 @@ watch(
   }, { deep: true, immediate: true }
 )
 
-// Elastic Search Function
+// ELASTIC SEARCH FUNCTION
 async function searchES() {
-  // collections.value = []
-  // hits.value = []
   if (
     (route.query.q && route.query.q !== '') ||
     (route.query.filters &&
@@ -125,14 +123,6 @@ async function searchES() {
         config.exploreCollection.filters
       ))
   ) {
-    if (!page.title) {
-      const data = await $graphql.default.request(
-        COLLECTIONS_EXPLORE_LIST
-      )
-      page.title = _get(data, 'entry.title', '')
-      page.text = _get(data, 'entry.text', '')
-    }
-
     console.log('Search ES HITS query,', route.query.q)
     const queryText = route.query.q || '*'
     const results = await $dataApi.keywordSearchWithFilters(
@@ -147,35 +137,19 @@ async function searchES() {
       config.exploreCollection.resultFields,
       config.exploreCollection.filters
     )
-    console.log('getsearchdata method:' + JSON.stringify(results))
-    collections.value = []
+
     hits.value = []
     if (results && results.hits && results.hits.total.value > 0) {
+      console.log('Search ES HITS,', results.hits.hits)
       hits.value = results.hits.hits
-      collections.value = []
       noResultsFound.value = false
     } else {
       hits.value = []
-      collections.value = []
       noResultsFound.value = true
-    }
-    searchGenericQuery.value = {
-      queryText: route.query.q || '',
-      queryFilters:
-        (route.query.filters &&
-          JSON.parse(route.query.filters)) ||
-        {},
     }
   } else {
     hits.value = []
     noResultsFound.value = false
-    // if route queries are empty fetch data from craft
-    const data = await $graphql.default.request(
-      COLLECTIONS_EXPLORE_LIST
-    )
-    // //console.log("data:" + data)
-    page.value = _get(data, 'entry', {})
-    collections.value = _get(data, 'entries', [])
   }
 }
 
@@ -282,11 +256,11 @@ onMounted(async () => {
       class="section-no-top-margin"
     >
       <h2
-        v-if="$route.query.q"
+        v-if="route.query.q"
         class="about-results"
       >
         Displaying {{ hits.length }} results for
-        <strong><em>“{{ $route.query.q }}”</em></strong>
+        <strong><em>“{{ route.query.q }}”</em></strong>
       </h2>
 
       <h2
@@ -305,7 +279,7 @@ onMounted(async () => {
     >
       <div class="error-text">
         <rich-text>
-          <h2>Search for “{{ $route.query.q }}” not found.</h2>
+          <h2>Search for “{{ route.query.q }}” not found.</h2>
           <p>
             We can’t find the term you are looking for on this page,
             but we're here to help. <br>

--- a/pages/collections/explore/index.vue
+++ b/pages/collections/explore/index.vue
@@ -1,275 +1,265 @@
 <script setup>
 // LODASH
-import _get from "lodash/get"
+import _get from 'lodash/get'
 
 // UTILITIES
-import removeTags from "../utils/removeTags"
+import removeTags from '../utils/removeTags'
 
 // GQL
-import EXPLORE_COLLECTIONS from "../gql/queries/CollectionsExploreList.gql"
+import EXPLORE_COLLECTIONS from '../gql/queries/CollectionsExploreList.gql'
 
 // ELASTIC SEARCH UTILITIES
-import getListingFilters from "../utils/getListingFilters"
-import config from "../utils/searchConfig"
-import queryFilterHasValues from "../utils/queryFilterHasValues"
+// import getListingFilters from '../utils/getListingFilters'
+// import config from '../utils/searchConfig'
+// import queryFilterHasValues from '../utils/queryFilterHasValues'
 
-const { $graphql, $dataApi } = useNuxtApp()
+const { $graphql } = useNuxtApp()
+
+// ASYNC DATA
 const { data, error } = await useAsyncData('collection', async () => {
   const data = await $graphql.default.request(COLLECTIONS_EXPLORE_LIST)
   return data
 })
+if (error.value) {
+  throw createError({
+    ...error.value, statusMessage: 'Page not found.', fatal: true
+  })
+}
+
+if (!data.value.entry) {
+  throw createError({ statusCode: 404, message: 'Page not found', fatal: true })
+}
 
 // ROUTING
 const route = useRoute()
+
+// DATA
+const page = ref(_get(data.value, 'entry', {}))
+
+const collections = ref(_get(data.value, 'entries', []))
+
+// TODO: change these into constants
+// data() {
+//   return {
+//     page: {},
+//     collections: [],
+//     hits: [],
+//     title: "",
+//     noResultsFound: false,
+//     searchFilters: [],
+//     searchGenericQuery: {
+//       queryText: this.$route.query.q || "",
+//       queryFilters:
+//         (this.$route.query.filters &&
+//           JSON.parse(this.$route.query.filters)) ||
+//         {},
+//     },
+//   }
+// }
+
 definePageMeta({
   layout: 'default',
   path: '/collections/explore',
   alias: ['/listing-collections/explore'],
 })
 
-const page = ref(_get(data.value, 'entry', {}))
-const collections = ref(_get(data.value, 'entries', []))
+/* TODO: Refactor when search functionality is ready */
+// async fetch() {
+// this.collections = []
+// this.hits = []
+// if (
+//   (this.$route.query.q && this.$route.query.q !== "") ||
+//   (this.$route.query.filters &&
+//     queryFilterHasValues(
+//       this.$route.query.filters,
+//       config.exploreCollection.filters
+//     ))
+// ) {
+//   if (!this.page.title) {
+//     const data = await this.$graphql.default.request(
+//       COLLECTIONS_EXPLORE_LIST
+//     )
+//     this.page["title"] = _get(data, "entry.title", "")
+//     this.page["text"] = _get(data, "entry.text", "")
+//   }
+//   let query_text = this.$route.query.q || "*"
+//   const results = await this.$dataApi.keywordSearchWithFilters(
+//     query_text,
+//     config.exploreCollection.searchFields,
+//     "sectionHandle:collection",
+//     (this.$route.query.filters &&
+//       JSON.parse(this.$route.query.filters)) ||
+//     {},
+//     config.exploreCollection.sortField,
+//     config.exploreCollection.orderBy,
+//     config.exploreCollection.resultFields,
+//     config.exploreCollection.filters
+//   )
+//   //console.log("getsearchdata method:" + JSON.stringify(results))
+//   this.collections = []
+//   this.hits = []
+//   if (results && results.hits && results.hits.total.value > 0) {
+//     this.hits = results.hits.hits
+//     this.collections = []
+//     this.noResultsFound = false
+//   } else {
+//     this.hits = []
+//     this.collections = []
+//     this.noResultsFound = true
+//   }
+//   this.searchGenericQuery = {
+//     queryText: this.$route.query.q || "",
+//     queryFilters:
+//       (this.$route.query.filters &&
+//         JSON.parse(this.$route.query.filters)) ||
+//       {},
+//   }
+// } else {
+//   this.hits = []
+//   this.noResultsFound = false
+//   // if route queries are empty fetch data from craft
+//   const data = await this.$graphql.default.request(
+//     COLLECTIONS_EXPLORE_LIST
+//   )
+//   // //console.log("data:" + data)
+//   this.page = _get(data, "entry", {})
+//   this.collections = _get(data, "entries", [])
+// }
+// }
 
-if (error.value) {
-  throw createError({
-    ...error.value, statusMessage: 'Page not found.', fatal: true
-  })
-}
-if (!data.value.entry) {
-  throw createError({ statusCode: 404, message: 'Page not found', fatal: true })
-}
+// HEAD
 
-// ASYNC DATA
-const { data, error } = await useAsyncData('explore-collections', async () => {
-  const data = await $graphql.default.request(ACCESS_COLLECTIONS)
-  return data
+useHead({
+  title: page.value ? page.value.title : '... loading',
+  meta: [
+    {
+      hid: 'description',
+      name: 'description',
+      content: removeTags(page.value.summary),
+    }
+  ],
 })
-  async asyncData({ $graphql, route }) {
-  const data = await $graphql.default.request(
-    COLLECTIONS_EXPLORE_LIST,
-    {}
-  )
 
-  //   // //console.log("data:" + data)
-
-  //   return {
-  //     page: _get(data, "entry", {}),
-  //     collections: _get(data, "entries", {}),
-  //   }
-  // }
-
-  data() {
+// COMPUTED
+const parsedCollectionList = computed(() => {
+  return this.collections.map((obj) => {
     return {
-      page: {},
-      collections: [],
-      hits: [],
-      title: "",
-      noResultsFound: false,
-      searchFilters: [],
-      searchGenericQuery: {
-        queryText: this.$route.query.q || "",
-        queryFilters:
-          (this.$route.query.filters &&
-            JSON.parse(this.$route.query.filters)) ||
-          {},
-      },
+      ...obj,
+      to: obj.externalResourceUrl
+        ? obj.externalResourceUrl
+        : `/${obj.uri}`,
+      image: _get(obj, 'heroImage[0]image[0]', null),
+      category: obj.category.join(', '),
+      title: _get(obj, 'title', ''),
+      text: _get(obj, 'text', ''),
     }
-  }
+  })
+})
 
-  async fetch() {
-    this.collections = []
-    this.hits = []
-    if (
-      (this.$route.query.q && this.$route.query.q !== "") ||
-      (this.$route.query.filters &&
-        queryFilterHasValues(
-          this.$route.query.filters,
-          config.exploreCollection.filters
-        ))
-    ) {
-      if (!this.page.title) {
-        const data = await this.$graphql.default.request(
-          COLLECTIONS_EXPLORE_LIST
-        )
-        this.page["title"] = _get(data, "entry.title", "")
-        this.page["text"] = _get(data, "entry.text", "")
-      }
-      let query_text = this.$route.query.q || "*"
-      const results = await this.$dataApi.keywordSearchWithFilters(
-        query_text,
-        config.exploreCollection.searchFields,
-        "sectionHandle:collection",
-        (this.$route.query.filters &&
-          JSON.parse(this.$route.query.filters)) ||
-        {},
-        config.exploreCollection.sortField,
-        config.exploreCollection.orderBy,
-        config.exploreCollection.resultFields,
-        config.exploreCollection.filters
-      )
-      //console.log("getsearchdata method:" + JSON.stringify(results))
-      this.collections = []
-      this.hits = []
-      if (results && results.hits && results.hits.total.value > 0) {
-        this.hits = results.hits.hits
-        this.collections = []
-        this.noResultsFound = false
-      } else {
-        this.hits = []
-        this.collections = []
-        this.noResultsFound = true
-      }
-      this.searchGenericQuery = {
-        queryText: this.$route.query.q || "",
-        queryFilters:
-          (this.$route.query.filters &&
-            JSON.parse(this.$route.query.filters)) ||
-          {},
-      }
-    } else {
-      this.hits = []
-      this.noResultsFound = false
-      // if route queries are empty fetch data from craft
-      const data = await this.$graphql.default.request(
-        COLLECTIONS_EXPLORE_LIST
-      )
-      // //console.log("data:" + data)
-      this.page = _get(data, "entry", {})
-      this.collections = _get(data, "entries", [])
+const parsedAssociatedTopics = computed(() => {
+  return this.page.associatedTopics.map((obj) => {
+    return {
+      ...obj,
+      to: obj.externalResourceUrl
+        ? obj.externalResourceUrl
+        : `/${obj.uri}`,
     }
-  },
-
-
-
-  // HEAD
-  useHead({
-    title: page.value ? page.value.title : '... loading',
-    meta: [
-      {
-        hid: 'description',
-        name: 'description',
-        content: removeTags(page.value.summary),
-      }
-    ],
   })
+})
 
-  // COMPUTED
-  const parsedCollectionList = computed(() => {
-    return this.collections.map((obj) => {
-      return {
-        ...obj,
-        to: obj.externalResourceUrl
-          ? obj.externalResourceUrl
-          : `/${obj.uri}`,
-        image: _get(obj, "heroImage[0]image[0]", null),
-        category: obj.category.join(", "),
-        title: _get(obj, "title", ""),
-        text: _get(obj, "text", ""),
-      }
-    })
-  })
+/* TODO: Enable when search functionality is ready */
+// const parsedPlaceholder = computed(() => {
+//   return `Search ${this.page.title}`
+// })
 
-  const parsedAssociatedTopics = computed(() => {
-    return this.page.associatedTopics.map((obj) => {
-      return {
-        ...obj,
-        to: obj.externalResourceUrl
-          ? obj.externalResourceUrl
-          : `/${obj.uri}`,
-      }
-    })
-  })
+// const parseHitsResults = computed(() => {
+//   return this.parseHits(this.hits)
+// })
 
-  const parsedPlaceholder = computed(() => {
-    return `Search ${this.page.title}`
-  })
+// METHODS
+// ENABLE PREVIEW MODE
 
-  const parseHitsResults = computed(() => {
-    return this.parseHits(this.hits)
-  })
+/* TODO: Incorporate when search functionality is ready? */
+// Watch route for new queries
+// watch: {
+//   "$route.query": "$fetch",
+//     "$route.query.q"(newValue) {
+//     //console.log("watching querytEXT:" + newValue)
+//   },
+//   "$route.query.filters"(newValue) {
+//     //console.log("watching filters:" + newValue)
+//   },
+// }
 
-  // METHODS
-  // ENABLE PREVIEW MODE
+// watch(() => route.query, (newVal, oldVal) => {
 
-  // Watch route for new queries
-  watch: {
-    "$route.query": "$fetch",
-      "$route.query.q"(newValue) {
-      //console.log("watching querytEXT:" + newValue)
-    },
-    "$route.query.filters"(newValue) {
-      //console.log("watching filters:" + newValue)
-    },
-  }
+// }, { deep: true, immediate: true })
 
-  // watch(() => route.query, (newVal, oldVal) => {
+//   async mounted() {
+//   //console.log("In mounted")
+//   this.setFilters()
+// }
 
-  // }, { deep: true, immediate: true })
+// ES watcher
+/* TODO: Incorporate when search functionality is ready? */
+// async function setFilters() {
+//   const searchAggsResponse = await this.$dataApi.getAggregations(
+//     config.exploreCollection.filters,
+//     "collection"
+//   )
+//   /*console.log(
+//       "Search Aggs Response: " + JSON.stringify(searchAggsResponse)
+//   )*/
+//   searchFilters.value = getListingFilters(
+//     searchAggsResponse,
+//     config.exploreCollection.filters
+//   )
+// }
 
-  //   async mounted() {
-  //   //console.log("In mounted")
-  //   this.setFilters()
-  // }
+/* TODO: Incorporate when search functionality is ready? */
+// function parseHits(hits = []) {
+//   return hits?.map((obj) => {
+//     return {
+//       ...obj["_source"],
+//       to: obj["_source"].externalResourceUrl
+//         ? obj["_source"].externalResourceUrl
+//         : `/${obj["_source"].uri}`,
+//       image: _get(obj["_source"], "heroImage[0]image[0]", null),
+//       category: obj["_source"].physicalDigital.join(", "),
+//     }
+//   })
+// }
 
-  // ES watcher
+/* TODO: Incorporate when search functionality is ready? */
+// function getSearchData(data) {
+//   // console.log("On the page getsearchdata called " + data)
+//   // this.page = {}
+//   // this.hits = []
+//   console.log('data text', data.text)
+//   console.log('data filters', JSON.stringify(data.filters))
+//   useRouter().push({
+//     path: "/collections/explore",
+//     query: {
+//       q: data.text,
+//       filters: JSON.stringify(data.filters),
+//     },
+//   })
+// }
 
-  async function setFilters() {
-    const searchAggsResponse = await this.$dataApi.getAggregations(
-      config.exploreCollection.filters,
-      "collection"
-    )
-    /*console.log(
-        "Search Aggs Response: " + JSON.stringify(searchAggsResponse)
-    )*/
-    searchFilters.value = getListingFilters(
-      searchAggsResponse,
-      config.exploreCollection.filters
-    )
-  }
-
-  function parseHits(hits = []) {
-    return hits?.map((obj) => {
-      return {
-        ...obj["_source"],
-        to: obj["_source"].externalResourceUrl
-          ? obj["_source"].externalResourceUrl
-          : `/${obj["_source"].uri}`,
-        image: _get(obj["_source"], "heroImage[0]image[0]", null),
-        category: obj["_source"].physicalDigital.join(", "),
-      }
-    })
-  }
-
-  function getSearchData(data) {
-    // console.log("On the page getsearchdata called " + data)
-    // this.page = {}
-    // this.hits = []
-    console.log('data text', data.text)
-    console.log('data filters', JSON.stringify(data.filters))
-    useRouter().push({
-      path: "/collections/explore",
-      query: {
-        q: data.text,
-        filters: JSON.stringify(data.filters),
-      },
-    })
-  }
-
-
-  fetchOnServer: false,
-    // multiple components can return the same `fetchKey` and Nuxt will track them both separately
-    fetchKey: "explore-collections-index",
+// NOT A METHOD
+/* TODO: Refactor when search functionality is ready */
+// fetchOnServer: false,
+//   // multiple components can return the same `fetchKey` and Nuxt will track them both separately
+//   fetchKey: "explore-collections-index",
 
 </script>
-
-
 
 <template lang="html">
   <main
     id="main"
     class="page page-collections-explore"
   >
-    <nav-breadcrumb
+    <!-- <nav-breadcrumb
       to="/collections"
       title="Explore Featured Collections"
       parent-title="Collections"
@@ -278,22 +268,22 @@ const { data, error } = await useAsyncData('explore-collections', async () => {
     <masthead-secondary
       :title="page.title"
       :text="page.summary"
-    />
+    /> -->
 
     <!-- SEARCH
                 Filters by physical/digital & subject area -->
-    <search-generic
+    <!-- <search-generic
       search-type="about"
       :filters="searchFilters"
       class="generic-search"
       :search-generic-query="searchGenericQuery"
       :placeholder="parsedPlaceholder"
       @search-ready="getSearchData"
-    />
+    /> -->
 
-    <section-wrapper theme="divider">
+    <!-- <section-wrapper theme="divider">
       <divider-way-finder class="search-margin" />
-    </section-wrapper>
+    </section-wrapper> -->
 
     <!-- DELETE AT THE END -->
     <h3> {{ parsedCollectionList }}</h3>
@@ -306,8 +296,7 @@ const { data, error } = await useAsyncData('explore-collections', async () => {
     <hr>
     <h3>{{ `On the page getsearchdata called ${data}` }}</h3>
 
-
-    <section-wrapper
+    <!-- <section-wrapper
       v-show="page &&
         parsedCollectionList &&
         parsedCollectionList.length &&
@@ -317,10 +306,10 @@ const { data, error } = await useAsyncData('explore-collections', async () => {
       class="section-no-top-margin"
     >
       <section-teaser-card :items="parsedCollectionList" />
-    </section-wrapper>
+    </section-wrapper> -->
 
     <!-- FILTERS -->
-    <section-wrapper
+    <!-- <section-wrapper
       v-show="hits && hits.length > 0"
       class="section-no-top-margin"
     >
@@ -339,10 +328,10 @@ const { data, error } = await useAsyncData('explore-collections', async () => {
         Displaying {{ hits.length }} results
       </h2>
       <section-teaser-card :items="parseHitsResults" />
-    </section-wrapper>
+    </section-wrapper> -->
 
     <!-- NO RESULTS -->
-    <section-wrapper
+    <!-- <section-wrapper
       v-show="noResultsFound"
       class="section-no-top-margin"
     >
@@ -370,16 +359,16 @@ const { data, error } = await useAsyncData('explore-collections', async () => {
           </ul>
         </rich-text>
       </div>
-    </section-wrapper>
+    </section-wrapper> -->
 
-    <section-wrapper>
+    <!-- <section-wrapper>
       <divider-way-finder
         class="divider-way-finder"
         color="default"
       />
-    </section-wrapper>
+    </section-wrapper> -->
 
-    <section-wrapper>
+    <!-- <section-wrapper>
       <section-cards-with-illustrations
         class="section"
         :items="parsedAssociatedTopics"
@@ -387,10 +376,9 @@ const { data, error } = await useAsyncData('explore-collections', async () => {
         to="/help/services-resources"
         section-title="Associated Topics"
       />
-    </section-wrapper>
+    </section-wrapper> -->
   </main>
 </template>
-
 
 <style
   lang="scss"

--- a/pages/collections/explore/index.vue
+++ b/pages/collections/explore/index.vue
@@ -1,0 +1,383 @@
+<script setup>
+
+// LODASH
+import _get from "lodash/get"
+
+// ELASTIC SEARCH UTILITIES
+import getListingFilters from "../utils/getListingFilters"
+import config from "../utils/searchConfig"
+import queryFilterHasValues from "../utils/queryFilterHasValues"
+
+// UTILITIES
+import removeTags from "../utils/removeTags"
+
+// GQL
+import COLLECTIONS_EXPLORE_LIST from "../gql/queries/CollectionsExploreList.gql"
+
+// ROUTING
+const route = useRoute()
+definePageMeta({
+  layout: 'default',
+  path: '/collections/explore',
+  alias: ['/listing-collections/explore'],
+})
+
+// ASYNC DATA
+// const { data, error } = await useAsyncData('access-collections', async () => {
+//   const data = await $graphql.default.request(ACCESS_COLLECTIONS)
+//   return data
+// })
+  async asyncData({ $graphql, route }) {
+  const data = await $graphql.default.request(
+    COLLECTIONS_EXPLORE_LIST,
+    {}
+  )
+
+  // //console.log("data:" + data)
+  // const page = ref(_get(data.value, 'entry', {}))
+  return {
+    page: _get(data, "entry", {}),
+    collections: _get(data, "entries", {}),
+  }
+}
+
+data() {
+  return {
+    page: {},
+    collections: [],
+    hits: [],
+    title: "",
+    noResultsFound: false,
+    searchFilters: [],
+    searchGenericQuery: {
+      queryText: this.$route.query.q || "",
+      queryFilters:
+        (this.$route.query.filters &&
+          JSON.parse(this.$route.query.filters)) ||
+        {},
+    },
+  }
+}
+
+  async fetch() {
+  this.collections = []
+  this.hits = []
+  if (
+    (this.$route.query.q && this.$route.query.q !== "") ||
+    (this.$route.query.filters &&
+      queryFilterHasValues(
+        this.$route.query.filters,
+        config.exploreCollection.filters
+      ))
+  ) {
+    if (!this.page.title) {
+      const data = await this.$graphql.default.request(
+        COLLECTIONS_EXPLORE_LIST
+      )
+      this.page["title"] = _get(data, "entry.title", "")
+      this.page["text"] = _get(data, "entry.text", "")
+    }
+    let query_text = this.$route.query.q || "*"
+    const results = await this.$dataApi.keywordSearchWithFilters(
+      query_text,
+      config.exploreCollection.searchFields,
+      "sectionHandle:collection",
+      (this.$route.query.filters &&
+        JSON.parse(this.$route.query.filters)) ||
+      {},
+      config.exploreCollection.sortField,
+      config.exploreCollection.orderBy,
+      config.exploreCollection.resultFields,
+      config.exploreCollection.filters
+    )
+    //console.log("getsearchdata method:" + JSON.stringify(results))
+    this.collections = []
+    this.hits = []
+    if (results && results.hits && results.hits.total.value > 0) {
+      this.hits = results.hits.hits
+      this.collections = []
+      this.noResultsFound = false
+    } else {
+      this.hits = []
+      this.collections = []
+      this.noResultsFound = true
+    }
+    this.searchGenericQuery = {
+      queryText: this.$route.query.q || "",
+      queryFilters:
+        (this.$route.query.filters &&
+          JSON.parse(this.$route.query.filters)) ||
+        {},
+    }
+  } else {
+    this.hits = []
+    this.noResultsFound = false
+    // if route queries are empty fetch data from craft
+    const data = await this.$graphql.default.request(
+      COLLECTIONS_EXPLORE_LIST
+    )
+    // //console.log("data:" + data)
+    this.page = _get(data, "entry", {})
+    this.collections = _get(data, "entries", [])
+  }
+},
+
+
+
+// HEAD
+useHead({
+  title: page.value ? page.value.title : '... loading',
+  meta: [
+    {
+      hid: 'description',
+      name: 'description',
+      content: removeTags(page.value.summary),
+    }
+  ],
+})
+
+// COMPUTED
+const parsedCollectionList = computed(() => {
+  return this.collections.map((obj) => {
+    return {
+      ...obj,
+      to: obj.externalResourceUrl
+        ? obj.externalResourceUrl
+        : `/${obj.uri}`,
+      image: _get(obj, "heroImage[0]image[0]", null),
+      category: obj.category.join(", "),
+      title: _get(obj, "title", ""),
+      text: _get(obj, "text", ""),
+    }
+  })
+})
+
+const parsedAssociatedTopics = computed(() => {
+  return this.page.associatedTopics.map((obj) => {
+    return {
+      ...obj,
+      to: obj.externalResourceUrl
+        ? obj.externalResourceUrl
+        : `/${obj.uri}`,
+    }
+  })
+})
+
+const parsedPlaceholder = computed(() => {
+  return `Search ${this.page.title}`
+})
+
+const parseHitsResults = computed(() => {
+  return this.parseHits(this.hits)
+})
+
+// METHODS
+// ENABLE PREVIEW MODE
+
+// Watch route for new queries
+watch: {
+  "$route.query": "$fetch",
+    "$route.query.q"(newValue) {
+    //console.log("watching querytEXT:" + newValue)
+  },
+  "$route.query.filters"(newValue) {
+    //console.log("watching filters:" + newValue)
+  },
+}
+
+// watch(() => route.query, (newVal, oldVal) => {
+
+// }, { deep: true, immediate: true })
+
+//   async mounted() {
+//   //console.log("In mounted")
+//   this.setFilters()
+// }
+
+// ES watcher
+
+async function setFilters() {
+  const searchAggsResponse = await this.$dataApi.getAggregations(
+    config.exploreCollection.filters,
+    "collection"
+  )
+  /*console.log(
+      "Search Aggs Response: " + JSON.stringify(searchAggsResponse)
+  )*/
+  searchFilters.value = getListingFilters(
+    searchAggsResponse,
+    config.exploreCollection.filters
+  )
+}
+
+function parseHits(hits = []) {
+  return hits?.map((obj) => {
+    return {
+      ...obj["_source"],
+      to: obj["_source"].externalResourceUrl
+        ? obj["_source"].externalResourceUrl
+        : `/${obj["_source"].uri}`,
+      image: _get(obj["_source"], "heroImage[0]image[0]", null),
+      category: obj["_source"].physicalDigital.join(", "),
+    }
+  })
+}
+
+function getSearchData(data) {
+  // console.log("On the page getsearchdata called " + data)
+  // this.page = {}
+  // this.hits = []
+  console.log('data text', data.text)
+  console.log('data filters', JSON.stringify(data.filters))
+  useRouter().push({
+    path: "/collections/explore",
+    query: {
+      q: data.text,
+      filters: JSON.stringify(data.filters),
+    },
+  })
+}
+
+
+fetchOnServer: false,
+  // multiple components can return the same `fetchKey` and Nuxt will track them both separately
+  fetchKey: "explore-collections-index",
+
+</script>
+
+
+
+<template lang="html">
+  <main
+    id="main"
+    class="page page-collections-explore"
+  >
+    <nav-breadcrumb
+      to="/collections"
+      title="Explore Featured Collections"
+      parent-title="Collections"
+    />
+
+    <masthead-secondary
+      :title="page.title"
+      :text="page.summary"
+    />
+
+    <!-- SEARCH
+                Filters by physical/digital & subject area -->
+    <search-generic
+      search-type="about"
+      :filters="searchFilters"
+      class="generic-search"
+      :search-generic-query="searchGenericQuery"
+      :placeholder="parsedPlaceholder"
+      @search-ready="getSearchData"
+    />
+
+    <section-wrapper theme="divider">
+      <divider-way-finder class="search-margin" />
+    </section-wrapper>
+
+    <!-- DELETE AT THE END -->
+    <h3> {{ parsedCollectionList }}</h3>
+    <hr>
+    <h3>{{ parsedAssociatedTopics }}</h3>
+    <hr>
+    <h3> {{ parsedPlaceholder }}</h3>
+    <hr>
+    <h3>{{ parseHitsResults }}</h3>
+    <hr>
+    <h3>{{ `On the page getsearchdata called ${data}` }}</h3>
+
+
+    <section-wrapper
+      v-show="page &&
+        parsedCollectionList &&
+        parsedCollectionList.length &&
+        hits.length == 0 &&
+        !noResultsFound
+        "
+      class="section-no-top-margin"
+    >
+      <section-teaser-card :items="parsedCollectionList" />
+    </section-wrapper>
+
+    <!-- FILTERS -->
+    <section-wrapper
+      v-show="hits && hits.length > 0"
+      class="section-no-top-margin"
+    >
+      <h2
+        v-if="$route.query.q"
+        class="about-results"
+      >
+        Displaying {{ hits.length }} results for
+        <strong><em>“{{ $route.query.q }}”</em></strong>
+      </h2>
+
+      <h2
+        v-else
+        class="about-results"
+      >
+        Displaying {{ hits.length }} results
+      </h2>
+      <section-teaser-card :items="parseHitsResults" />
+    </section-wrapper>
+
+    <!-- NO RESULTS -->
+    <section-wrapper
+      v-show="noResultsFound"
+      class="section-no-top-margin"
+    >
+      <div class="error-text">
+        <rich-text>
+          <h2>Search for “{{ $route.query.q }}” not found.</h2>
+          <p>
+            We can’t find the term you are looking for on this page,
+            but we're here to help. <br>
+            Try searching the whole site from
+            <a href="https://library.ucla.edu">UCLA Library Home</a>, or try one of the these regularly visited
+            links:
+          </p>
+          <ul>
+            <li>
+              <a href="https://www.library.ucla.edu/research-teaching-support/research-help">Research Help</a>
+            </li>
+            <li>
+              <a href="/help/services-resources/ask-us">Ask Us</a>
+            </li>
+            <li>
+              <a href="https://www.library.ucla.edu/use/access-privileges/disability-resources">Accessibility
+                Resources</a>
+            </li>
+          </ul>
+        </rich-text>
+      </div>
+    </section-wrapper>
+
+    <section-wrapper>
+      <divider-way-finder
+        class="divider-way-finder"
+        color="default"
+      />
+    </section-wrapper>
+
+    <section-wrapper>
+      <section-cards-with-illustrations
+        class="section"
+        :items="parsedAssociatedTopics"
+        button-text="All services & resources"
+        to="/help/services-resources"
+        section-title="Associated Topics"
+      />
+    </section-wrapper>
+  </main>
+</template>
+
+
+<style
+  lang="scss"
+  scoped
+>
+.page-collections-explore {}
+</style>

--- a/pages/collections/explore/index.vue
+++ b/pages/collections/explore/index.vue
@@ -199,8 +199,6 @@ const parseHitsResults = computed(() => {
 // This is event handler which is invoked by search-generic component selections
 function getSearchData(data) {
   // console.log("On the page getsearchdata called " + data)
-  // page = {}
-  // hits = []
   console.log('data text', data.text)
   console.log('data filters', JSON.stringify(data.filters))
   useRouter().push({
@@ -240,17 +238,6 @@ onMounted(async () => {
     id="main"
     class="page page-collections-explore"
   >
-    <!--
-    THESE ALL WORK
-    <h3>DATA: {{ data }}</h3>
-    <h3>PAGE: {{ page }}</h3>
-    <h3>COLLECTIONS: {{ collections }}</h3>
-    -->
-
-    <!-- <h3>parseHitsResults -- {{ parseHitsResults }}</h3> -->
-    <!-- <hr>
-    <h3>HITS -- {{ hits.value }}</h3> -->
-
     <nav-breadcrumb
       to="/collections"
       title="Explore Featured Collections"

--- a/pages/help/services-resources/index.vue
+++ b/pages/help/services-resources/index.vue
@@ -315,9 +315,8 @@ const parseHitsResults = computed(() => {
     </section-wrapper>
 
     <section-wrapper
-      v-if="
-        (page.serviceOrResource || page.workshopseries) &&
-          hits.length == 0
+      v-if="(page.serviceOrResource || page.workshopseries) &&
+        hits.length == 0
       "
       class="section-no-top-margin"
     >
@@ -395,7 +394,10 @@ const parseHitsResults = computed(() => {
   </main>
 </template>
 
-<style lang="scss" scoped>
+<style
+  lang="scss"
+  scoped
+>
 .page-help {
   :deep(label.label) {
     text-transform: capitalize;


### PR DESCRIPTION
Connected to [APPS-2658](https://jira.library.ucla.edu/browse/APPS-258)
Connected to [APPS-2657](https://jira.library.ucla.edu/browse/APPS-2657)
Connected to [APPS-2670](https://uclalibrary.atlassian.net/browse/APPS-2670)

1. APPS-2658 Migrate collections/explore index page template to nuxt3 branch
2. APPS-2657 Enable Elastic Search on the Collections Explore Listing page
3. APPS-2670 Associated Topics FPB is not pulling in correct illustration for Card with Illustration component - external record

**Page converted to Nuxt3 ** collections/explore/index.vue

**Notes:**

1. I updated the query `BlockAssociatedTopicCardsFragment.gql` to include: iconName: `illustrationsResourcesAndServices` to fix the Article page FPB Associated Topics Illustrations for External Resources
2. `pages/help/services-resources/index.vue` & `pages/collections/access/index.vue` only have linting changes
3. 
<img width="1153" alt="Screenshot 2024-05-16 at 5 07 30 PM" src="https://github.com/UCLALibrary/library-website-nuxt/assets/751697/df5255bb-6189-40ec-8de3-d77ea56355a3">

<img width="962" alt="Screenshot 2024-05-16 at 5 33 40 PM" src="https://github.com/UCLALibrary/library-website-nuxt/assets/751697/1462883a-b468-4bb5-ab58-fb23139c485d">


[APPS-2658]: https://uclalibrary.atlassian.net/browse/APPS-2658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APPS-2657]: https://uclalibrary.atlassian.net/browse/APPS-2657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[APPS-2670]: https://uclalibrary.atlassian.net/browse/APPS-2670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ