### PR TITLE
fix: APPS-2682 intercept and wait on flaky tests

### DIFF
--- a/cypress/e2e/articlenewslistingpage.cy.js
+++ b/cypress/e2e/articlenewslistingpage.cy.js
@@ -1,19 +1,21 @@
 describe('Article News Listing page', () => {
   it('Visit the Article News Listing Page', () => {
+    cy.intercept('/about/news').as('getNews')
     cy.visit('/about/news')
+    cy.wait('@getNews').then(() => {
+      // UCLA Library brand
+      cy.get('.logo-ucla').should('be.visible')
+      cy.get('.page-news').should('be.visible')
+      cy.get('h1.title').should('contain', 'Library News')
+      // cy.get('.search-generic-filter-buttons').find('button').should('have.length', 2)
 
-    // UCLA Library brand
-    cy.get('.logo-ucla').should('be.visible')
-    cy.get('.page-news').should('be.visible')
-    cy.get('h1.title').should('contain', 'Library News')
-    // cy.get('.search-generic-filter-buttons').find('button').should('have.length', 2)
+      // cy.get('.search-generic-filter-buttons').find('button').each(($el, index, $list) => {
+      //   cy.wrap($el).click()
+      //   cy.get('fieldset.base-checkbox-group > ul.list > li.list-item').find('label').should('have.length.greaterThan', 0)
+      // })
 
-    // cy.get('.search-generic-filter-buttons').find('button').each(($el, index, $list) => {
-    //   cy.wrap($el).click()
-    //   cy.get('fieldset.base-checkbox-group > ul.list > li.list-item').find('label').should('have.length.greaterThan', 0)
-    // })
-
-    cy.percySnapshot({ widths: [768, 992, 1200] })
+      cy.percySnapshot({ widths: [768, 992, 1200] })
+    })
   })
 
   // it('Visit News Article Listing page filter by category', () => {

--- a/cypress/e2e/collectionsexplorepage.cy.js
+++ b/cypress/e2e/collectionsexplorepage.cy.js
@@ -1,21 +1,23 @@
 describe('Explore Collection page', () => {
   it('Visit a Explore Collection Page', () => {
+    cy.intercept('/collections/explore').as('getExploreCollections')
     cy.visit('/collections/explore')
+    cy.wait('@getExploreCollections').then(() => {
+      // UCLA Library brand
+      cy.get('.logo-ucla').should('be.visible')
+      cy.get('.page-collections-explore').should('be.visible')
+      cy.get('h1.title').should(
+        'contain',
+        'Listing - Collections > Explore Collections'
+      )
+      cy.get('.search-generic-filter-buttons').find('button').should('have.length', 2)
 
-    // UCLA Library brand
-    cy.get('.logo-ucla').should('be.visible')
-    cy.get('.page-collections-explore').should('be.visible')
-    cy.get('h1.title').should(
-      'contain',
-      'Listing - Collections > Explore Collections'
-    )
-    cy.get('.search-generic-filter-buttons').find('button').should('have.length', 2)
-
-    cy.get('.search-generic-filter-buttons').find('button').each(($el, index, $list) => {
-      cy.wrap($el).click()
-      cy.get('fieldset.base-checkbox-group > ul.list > li.list-item').find('label').should('have.length.greaterThan', 0)
+      cy.get('.search-generic-filter-buttons').find('button').each(($el, index, $list) => {
+        cy.wrap($el).click()
+        cy.get('fieldset.base-checkbox-group > ul.list > li.list-item').find('label').should('have.length.greaterThan', 0)
+      })
+      cy.percySnapshot({ widths: [768, 992, 1200] })
     })
-    cy.percySnapshot({ widths: [768, 992, 1200] })
   })
 
   it('Search Found', () => {

--- a/cypress/e2e/eventsexhibitionslist.cy.js
+++ b/cypress/e2e/eventsexhibitionslist.cy.js
@@ -1,11 +1,10 @@
 describe('Events & Exhibitions List page', () => {
   it('Visits a Events & Exhibitions List Page', () => {
-    cy.intercept('/visit/events-exhibitions*').as('getEventsRoutes')
-    cy.visit('/visit/events-exhibitions', { timeout: 30000 })
+    cy.intercept('/visit/events-exhibitions').as('getEventsRoutes')
+    cy.visit('/visit/events-exhibitions')
     cy.wait('@getEventsRoutes').then(() => {
     // UCLA Library brand
       cy.get('.logo-ucla').should('be.visible')
-
       cy.get('.page-events-exhibits').should('be.visible')
       cy.get('h1.title').should('contain', 'Events & Exhibitions')
       cy.percySnapshot({ widths: [768, 992, 1200] })

--- a/cypress/e2e/policiesdetailpage.cy.js
+++ b/cypress/e2e/policiesdetailpage.cy.js
@@ -1,10 +1,13 @@
 describe('Policy Detail page', () => {
   it('Visits a Policy Detail Page', () => {
-    cy.visit('about/policies/shhh')
-    cy.get('.logo-ucla').should('be.visible')
-    // TODO following line will be uncommented when headers are working for Flexible page blocks
-    // cy.get(".page-anchor").scrollIntoView().should('be.visible')
-    cy.percySnapshot({ widths: [768, 992, 1200] })
+    cy.intercept('about/policies/shhh').as('getPolicyDetailRoute')
+    cy.visit('/about/policies/shhh')
+    cy.wait('@getPolicyDetailRoute').then(() => {
+      cy.get('.logo-ucla').should('be.visible')
+      // TODO following line will be uncommented when headers are working for Flexible page blocks
+      // cy.get(".page-anchor").scrollIntoView().should('be.visible')
+      cy.percySnapshot({ widths: [768, 992, 1200] })
+    })
   })
 
   context("When there isn't an entry in craft", () => {


### PR DESCRIPTION
Connected to [APPS-2682](https://jira.library.ucla.edu/browse/APPS-2682)

**Notes:**

Adding a bit more resilience to specific flaky page tests

**Time Report:**

This took me {x} hours to build this.

**Checklist:**

-   [ ] I added github label for semantic versioning
-   [ ] I double checked it looks like the designs
-   [ ] I completed any required mobile breakpoint styling
-   [ ] I completed any required hover state styling
-   [ ] I included a working spec file
-   [ ] I added notes above about how long it took to build this component
-   [ ] UX has reviewed this PR
-   [ ] I assigned this PR to someone to review


[APPS-2682]: https://uclalibrary.atlassian.net/browse/APPS-2682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ