### PR TITLE
fix: APPS-2711 Fix Vue-Skip-To in Nuxt3

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -7,6 +7,10 @@ const { enabled, state } = usePreviewMode()
       color="#ffe800"
       height="3"
     />
+    <vue-skip-to
+      to="#main"
+      label="Skip to main content"
+    />
     <NuxtLayout>
       <NuxtPage />
     </NuxtLayout>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -67,6 +67,10 @@ onMounted(async () => {
 </script>
 
 <template>
+  <vue-skip-to
+    to="#main"
+    label="Skip to main content"
+  />
   <div :class="classes">
     <!-- VueSkipTo to="#main" label="Skip to main content" / -->
     <!-- this is not working in static build -->
@@ -96,10 +100,7 @@ onMounted(async () => {
   </div>
 </template>
 
-<style
-  lang="scss"
-  scoped
->
+<style lang="scss" scoped>
 .layout-default {
   min-height: 100vh;
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -67,15 +67,8 @@ onMounted(async () => {
 </script>
 
 <template>
-  <vue-skip-to
-    to="#main"
-    label="Skip to main content"
-  />
   <div :class="classes">
-    <!-- VueSkipTo to="#main" label="Skip to main content" / -->
-    <!-- this is not working in static build -->
     <header-smart v-if="globalStore.header" />
-
     <section-wrapper
       class="section-alert"
       theme="divider"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"nuxt": "^3.11.2",
 		"nuxt-graphql-request": "^7.0.5",
 		"sass": "^1.66.1",
-		"ucla-library-design-tokens": "^5.8.0",
+		"ucla-library-design-tokens": "^5.12.6",
 		"ucla-library-website-components": "2.39.0-alpha.82"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"nuxt": "^3.11.2",
 		"nuxt-graphql-request": "^7.0.5",
 		"sass": "^1.66.1",
-		"ucla-library-design-tokens": "^5.12.6",
-		"ucla-library-website-components": "2.39.0-alpha.81"
+		"ucla-library-design-tokens": "^5.8.0",
+		"ucla-library-website-components": "2.39.0-alpha.82"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,8 +65,8 @@ devDependencies:
     specifier: ^5.12.6
     version: 5.12.6
   ucla-library-website-components:
-    specifier: 2.39.0-alpha.81
-    version: 2.39.0-alpha.81(typescript@5.4.3)(vue-router@4.3.0)(vue@3.4.21)
+    specifier: 2.39.0-alpha.82
+    version: 2.39.0-alpha.82(typescript@5.4.3)(vue-router@4.3.0)(vue@3.4.21)
 
 packages:
 
@@ -9293,8 +9293,8 @@ packages:
     resolution: {integrity: sha512-cHvHjWzkiDRCJre1S3naGCvObfs6l6hnvoRWcGfwgviihRea8ovfuURwVNhvHm5JeSurRBTVGqxekcahPs22OQ==}
     dev: true
 
-  /ucla-library-website-components@2.39.0-alpha.81(typescript@5.4.3)(vue-router@4.3.0)(vue@3.4.21):
-    resolution: {integrity: sha512-E6iIucixwFkPO8DZ/eJJOQfKBEgqOJ0H5/LgQxktzeqQCG+stsRRPtWSlr+pdfq63BKHrJ3+MWBDVgRaJ7YILA==}
+  /ucla-library-website-components@2.39.0-alpha.82(typescript@5.4.3)(vue-router@4.3.0)(vue@3.4.21):
+    resolution: {integrity: sha512-Uqj7K9Qnv5Hdtb+hzycfghTEKlvAWbv09XybcEPl7Omv6PPqk1AUSB8HHc7cjs8kLt2uC7SWcumuSg6hwwyAeg==}
     peerDependencies:
       vue: ^3.4
       vue-router: ^4.2.4


### PR DESCRIPTION
Connected to [APPS-2711](https://jira.library.ucla.edu/browse/APPS-2711)

**Preview:** https://deploy-preview-819--uclalibrary-test-nuxt3x.netlify.app/

**Notes:**

Re-enable Vue-Skip-To package after resolving underlying issue with SearchInput component
- See related PR: [Fix tab focus in-out of search input field](https://github.com/UCLALibrary/ucla-library-website-components/pull/514/)

**Checklist:**

-   [x] I added github label for semantic versioning
-   [x] I added notes
-   [x] I requested a PR review


[APPS-2711]: https://uclalibrary.atlassian.net/browse/APPS-2711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ