### PR TITLE
feat: Add rich text fragment to impact report FBP query

### DIFF
--- a/gql/fragments/collections/ImpactReportFpb.gql
+++ b/gql/fragments/collections/ImpactReportFpb.gql
@@ -9,6 +9,7 @@
 #import "../gql/fragments/BlockHighlightFragment.gql"
 #import "../gql/fragments/BlockImpactNumberCardsFragment.gql"
 #import "../gql/fragments/BlockGridGalleryCardsFragment.gql"
+#import "../gql/fragments/BlockRichTextFragment.gql"
 
 fragment ImpactReportFpb on ElementInterface {
     blocks: impactReportFpb {
@@ -47,6 +48,9 @@ fragment ImpactReportFpb on ElementInterface {
         }
         ... on impactReportFpb_cardWithImage_BlockType {
             ...BlockCardWithImageFragment
+        }
+        ... on impactReportFpb_richText_BlockType {
+            ...BlockRichTextFragment
         }
     }
 }


### PR DESCRIPTION
Connected to [APPS-2994](https://jira.library.ucla.edu/browse/APPS-2994)

**Query updated:** gql/fragments/collections/ImpactReportFpb.gql.vue

**Notes:**

Recently in Craft we updated ImpactReportFBP with new block -> Rich Text, to support this on the nuxt side, we need to update the GQL query

**Time Report:**

This took me 5 mins to work on this.



[APPS-2994]: https://uclalibrary.atlassian.net/browse/APPS-2994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ