### PR TITLE
fix: remove library.ucla.edu/givemusic and remove a trailing slash

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -405,7 +405,7 @@
 /search/eresources.cfm	/collections/access
 /search/journals	/collections/access
 /search/search-find	/collections/access
-/sel	/visit/locations/science-engineering-library/
+/sel	/visit/locations/science-engineering-library
 /sel-ems	/visit/locations/science-engineering-library
 /sel-geology	/visit/locations/science-engineering-library
 /sel/about/staff-directory	/visit/locations/science-engineering-library
@@ -638,4 +638,4 @@ https://www.clicc.ucla.edu/about/staff/abigail-connick/	/about/staff/abigail-con
 https://www.clicc.ucla.edu/about/staff/alice-hunt/	/about/staff/alice-hunt/
 https://www.clicc.ucla.edu/about/staff/charlie-h-castro/	/about/staff/charlie-h-castro/
 https://www.clicc.ucla.edu/about/staff/jonathan-fahn/	/about/staff/jonathan-fahn/
-https://library.ucla.edu/givemusic  https://giving.ucla.edu/campaign/?&OrgType=C&OrgNum=10100&fund=61516O
+


### PR DESCRIPTION
Connected to [APPS-3131](https://jira.library.ucla.edu/browse/APPS-3131)

Remove any reference to https://library.ucla.edu/* redirect source paths. 
Checked if all the 3 HAProxy URL redirects are in the redirects file in this app.

[APPS-3131]: https://uclalibrary.atlassian.net/browse/APPS-3131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ