### PR TITLE
feat: APPS-3272

### DIFF
--- a/composables/useIndexer.js
+++ b/composables/useIndexer.js
@@ -75,6 +75,3 @@ export default function useSearch() {
   }
   return { index }
 }
-
-
-

--- a/composables/useIndexer.js
+++ b/composables/useIndexer.js
@@ -1,14 +1,15 @@
-export default defineNuxtPlugin((nuxtApp) => {
-  // console.log("elastic search plugin index  :")
+export default function useSearch() {
   const esIndex = useRuntimeConfig().public.esTempIndex
   const esURL = useRuntimeConfig().public.esURL
   const esReadKey = useRuntimeConfig().public.esReadKey
   const esWriteKey = useRuntimeConfig().esWriteKey
   async function index(data, slug) {
+    // console.log("elastic search plugin index  :")
+
     // console.log('elastic search plugin index function :', esIndex)
 
     try {
-      if (process.env.NODE_ENV !== 'development' && data && slug && esIndex) {
+      if (data && slug && esIndex) {
         /* console.log(
                 "this is the elasticsearch plugin: " + JSON.stringify(data)
             ) */
@@ -47,7 +48,7 @@ export default defineNuxtPlugin((nuxtApp) => {
           )
           // console.log('Update document in ES', updateResponse)
           const updateJson = await updateResponse.text()
-          console.log('Update in ES', updateJson)
+          // console.log('Update in ES', updateJson)
         } else {
           const response = await fetch(
                     `${esURL}/${esIndex}/_doc/${slug}`,
@@ -72,13 +73,8 @@ export default defineNuxtPlugin((nuxtApp) => {
       throw new Error('Elastic Search Indexing failed ' + e) // TODO uncomment when cause is clear
     }
   }
+  return { index }
+}
 
-  return {
-    provide: {
-      elasticsearchplugin: {
-        index
-        // Make plugin available to all components
-      }
-    }
-  }
-})
+
+

--- a/composables/useSearch.ts
+++ b/composables/useSearch.ts
@@ -1,3 +1,7 @@
+export default function useSearch() {
+  return { siteSearch, getMapping, getAggregationsForSiteSearch, getAggregations, keywordSearchWithFilters }
+}
+
 /*
     {"id":"j6tUj4IBzYVXfPB9-JvU","name":"dev-es-key","api_key":"N_f0_5WSSae3QOvm4hlq0g","encoded":"ajZ0VWo0SUJ6WVZYZlBCOS1KdlU6Tl9mMF81V1NTYWUzUU92bTRobHEwZw=="}
 */
@@ -13,8 +17,8 @@ async function siteSearch(
   // https://www.elastic.co/guide/en/elasticsearch/reference/current/flattened.html
   if (
     config.public.esReadKey === '' ||
-        config.public.esURL === '' ||
-        config.public.esAlias === ''
+    config.public.esURL === '' ||
+    config.public.esAlias === ''
   )
     return
   // console.log('keyword:' + keyword)
@@ -36,10 +40,10 @@ async function siteSearch(
           must: [{
             query_string: {
               query: '(' +
-                                keyword +
-                                ' AND NOT(sectionHandle:event)) OR (' +
-                                keyword +
-                                ' AND startDateWithTime:[now TO *] AND sectionHandle:event)',
+                keyword +
+                ' AND NOT(sectionHandle:event)) OR (' +
+                keyword +
+                ' AND startDateWithTime:[now TO *] AND sectionHandle:event)',
               fields: [
                 'title^4',
                 'summary^3',
@@ -70,12 +74,12 @@ async function siteSearch(
   //   }
 
   const responseAlias = await fetch(
-        `${config.public.esURL}/_alias/${config.public.esAlias}`, {
-          headers: {
-            Authorization: `ApiKey ${config.public.esReadKey}`,
-            'Content-Type': 'application/json',
-          },
-        }
+    `${config.public.esURL}/_alias/${config.public.esAlias}`, {
+    headers: {
+      Authorization: `ApiKey ${config.public.esReadKey}`,
+      'Content-Type': 'application/json',
+    },
+  }
   )
   const dataAlias = await responseAlias.json()
 
@@ -84,47 +88,47 @@ async function siteSearch(
   const libguideIndex = Object.keys(dataAlias)[1].includes('libguides') ? Object.keys(dataAlias)[1] : Object.keys(dataAlias)[0]
 
   const response = await fetch(
-        `${config.public.esURL}/${config.public.esAlias}/_search`, {
-          headers: {
-            Authorization: `ApiKey ${config.public.esReadKey}`,
-            'Content-Type': 'application/json',
-          },
-          method: 'POST',
-          body: JSON.stringify({
-            from,
-            indices_boost: [{
-              [libraryIndex]: 3.0
+    `${config.public.esURL}/${config.public.esAlias}/_search`, {
+    headers: {
+      Authorization: `ApiKey ${config.public.esReadKey}`,
+      'Content-Type': 'application/json',
+    },
+    method: 'POST',
+    body: JSON.stringify({
+      from,
+      indices_boost: [{
+        [libraryIndex]: 3.0
+      },
+      {
+        [libguideIndex]: 1.3
+      }
+      ],
+      query: {
+        bool: {
+          must: [{
+            query_string: {
+              query: '(' +
+                keyword +
+                ' AND NOT(sectionHandle:event)) OR (' +
+                keyword +
+                ' AND startDateWithTime:[now TO *] AND sectionHandle:event)',
+              fields: [
+                'title^4',
+                'summary^3',
+                'text^3',
+                'fullText^2',
+                'richText^2',
+                'sectionHandle',
+                'sectionHandleDisplayName'
+              ],
+              fuzziness: 'auto',
             },
-            {
-              [libguideIndex]: 1.3
-            }
-            ],
-            query: {
-              bool: {
-                must: [{
-                  query_string: {
-                    query: '(' +
-                                    keyword +
-                                    ' AND NOT(sectionHandle:event)) OR (' +
-                                    keyword +
-                                    ' AND startDateWithTime:[now TO *] AND sectionHandle:event)',
-                    fields: [
-                      'title^4',
-                      'summary^3',
-                      'text^3',
-                      'fullText^2',
-                      'richText^2',
-                      'sectionHandle',
-                      'sectionHandleDisplayName'
-                    ],
-                    fuzziness: 'auto',
-                  },
-                },],
-                filter: [...parseFilterQuerySiteSearch(queryFilters, configMapping)],
-              },
-            },
-          }),
-        }
+          },],
+          filter: [...parseFilterQuerySiteSearch(queryFilters, configMapping)],
+        },
+      },
+    }),
+  }
   )
   const data = await response.json()
   return data
@@ -169,17 +173,17 @@ async function getMapping() {
   const config = useRuntimeConfig()
   if (
     config.public.esReadKey === '' ||
-        config.public.esURL === '' ||
-        config.public.esAlias === ''
+    config.public.esURL === '' ||
+    config.public.esAlias === ''
   )
     return
   const response = await fetch(
-        `${config.public.esURL}/${config.public.esAlias}/_mapping`, {
-          headers: {
-            Authorization: `ApiKey ${config.public.esReadKey}`,
-            // 'Content-Type': 'application/x-www-form-urlencoded',
-          },
-        }
+    `${config.public.esURL}/${config.public.esAlias}/_mapping`, {
+    headers: {
+      Authorization: `ApiKey ${config.public.esReadKey}`,
+      // 'Content-Type': 'application/x-www-form-urlencoded',
+    },
+  }
   )
   const data = await response.json()
   return data
@@ -190,22 +194,22 @@ async function getAggregationsForSiteSearch(fields) {
   const config = useRuntimeConfig()
   if (!fields || fields.length === 0) return
   const response = await fetch(
-        `${config.public.esURL}/${config.public.esAlias}/_search`, {
-          headers: {
-            Authorization: `ApiKey ${config.public.esReadKey}`,
-            'Content-Type': 'application/json',
-          },
-          method: 'POST',
-          body: JSON.stringify({
-            size: 0,
-            query: {
-              match_all: {},
-            },
-            aggs: {
-              ...parseFieldNames(fields),
-            },
-          }),
-        }
+    `${config.public.esURL}/${config.public.esAlias}/_search`, {
+    headers: {
+      Authorization: `ApiKey ${config.public.esReadKey}`,
+      'Content-Type': 'application/json',
+    },
+    method: 'POST',
+    body: JSON.stringify({
+      size: 0,
+      query: {
+        match_all: {},
+      },
+      aggs: {
+        ...parseFieldNames(fields),
+      },
+    }),
+  }
   )
   const data = await response.json()
   return data.aggregations
@@ -216,25 +220,25 @@ async function getAggregations(fields, sectionHandle) {
   const config = useRuntimeConfig()
   if (!fields || fields.length === 0) return
   const response = await fetch(
-        `${config.public.esURL}/${config.public.esAlias}/_search`, {
-          headers: {
-            Authorization: `ApiKey ${config.public.esReadKey}`,
-            'Content-Type': 'application/json',
-          },
-          method: 'POST',
-          body: JSON.stringify({
-            size: 0,
-            query: {
-              query_string: {
-                query: sectionHandle,
-                default_field: 'sectionHandle'
-              },
-            },
-            aggs: {
-              ...parseFieldNames(fields),
-            },
-          }),
-        }
+    `${config.public.esURL}/${config.public.esAlias}/_search`, {
+    headers: {
+      Authorization: `ApiKey ${config.public.esReadKey}`,
+      'Content-Type': 'application/json',
+    },
+    method: 'POST',
+    body: JSON.stringify({
+      size: 0,
+      query: {
+        query_string: {
+          query: sectionHandle,
+          default_field: 'sectionHandle'
+        },
+      },
+      aggs: {
+        ...parseFieldNames(fields),
+      },
+    }),
+  }
   )
   const data = await response.json()
   return data.aggregations
@@ -258,8 +262,8 @@ async function keywordSearchWithFilters(
   // console.log(config.public.esURL)
   if (
     config.public.esReadKey === '' ||
-        config.public.esURL === '' ||
-        config.public.esAlias === ''
+    config.public.esURL === '' ||
+    config.public.esAlias === ''
   )
     return
   // console.log('keyword:' + keyword)
@@ -292,12 +296,12 @@ async function keywordSearchWithFilters(
 
   // need to know fields to boost on for listing pages when searching like title etc
   const responseAlias = await fetch(
-        `${config.public.esURL}/_alias/${config.public.esAlias}`, {
-          headers: {
-            Authorization: `ApiKey ${config.public.esReadKey}`,
-            'Content-Type': 'application/json',
-          },
-        }
+    `${config.public.esURL}/_alias/${config.public.esAlias}`, {
+    headers: {
+      Authorization: `ApiKey ${config.public.esReadKey}`,
+      'Content-Type': 'application/json',
+    },
+  }
   )
   const dataAlias = await responseAlias.json()
 
@@ -305,37 +309,37 @@ async function keywordSearchWithFilters(
   const libraryIndex = !Object.keys(dataAlias)[0].includes('libguides') ? Object.keys(dataAlias)[0] : Object.keys(dataAlias)[1]
 
   const response = await fetch(
-        `${config.public.esURL}/${libraryIndex}/_search`, // replace alias with indexname
-        {
-          headers: {
-            Authorization: `ApiKey ${config.public.esReadKey}`,
-            'Content-Type': 'application/json',
-          },
-          method: 'POST',
-          body: JSON.stringify({
-            size: '1000',
-            _source: [...source],
-            query: {
-              bool: {
-                must: [{
-                  query_string: {
-                    query: keyword,
-                    fields: [...searchFields],
-                    fuzziness: 'auto',
-                  },
-                },
-                ...parseSectionHandle(sectionHandle),
-                ...parseFilterQuery(filters),
-                ...extraFilters,
-                ],
+    `${config.public.esURL}/${libraryIndex}/_search`, // replace alias with indexname
+    {
+      headers: {
+        Authorization: `ApiKey ${config.public.esReadKey}`,
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+      body: JSON.stringify({
+        size: '1000',
+        _source: [...source],
+        query: {
+          bool: {
+            must: [{
+              query_string: {
+                query: keyword,
+                fields: [...searchFields],
+                fuzziness: 'auto',
               },
             },
-            ...parseSort(sort, orderBy),
-            aggs: {
-              ...parseFieldNames(aggFields),
-            },
-          }),
-        }
+            ...parseSectionHandle(sectionHandle),
+            ...parseFilterQuery(filters),
+            ...extraFilters,
+            ],
+          },
+        },
+        ...parseSort(sort, orderBy),
+        aggs: {
+          ...parseFieldNames(aggFields),
+        },
+      }),
+    }
   )
   const data = await response.json()
   return data
@@ -413,17 +417,3 @@ function parseFieldNames(fields) {
   // console.log("aggsFields:" + JSON.stringify(aggsFields))
   return aggsFields
 }
-
-export default defineNuxtPlugin((nuxtApp) => {
-  return {
-    provide: {
-      dataApi: {
-        getMapping,
-        siteSearch,
-        keywordSearchWithFilters,
-        getAggregations,
-        getAggregationsForSiteSearch
-      }
-    }
-  }
-})

--- a/composables/useSearch.ts
+++ b/composables/useSearch.ts
@@ -75,11 +75,11 @@ async function siteSearch(
 
   const responseAlias = await fetch(
     `${config.public.esURL}/_alias/${config.public.esAlias}`, {
-    headers: {
-      Authorization: `ApiKey ${config.public.esReadKey}`,
-      'Content-Type': 'application/json',
-    },
-  }
+      headers: {
+        Authorization: `ApiKey ${config.public.esReadKey}`,
+        'Content-Type': 'application/json',
+      },
+    }
   )
   const dataAlias = await responseAlias.json()
 
@@ -89,46 +89,46 @@ async function siteSearch(
 
   const response = await fetch(
     `${config.public.esURL}/${config.public.esAlias}/_search`, {
-    headers: {
-      Authorization: `ApiKey ${config.public.esReadKey}`,
-      'Content-Type': 'application/json',
-    },
-    method: 'POST',
-    body: JSON.stringify({
-      from,
-      indices_boost: [{
-        [libraryIndex]: 3.0
+      headers: {
+        Authorization: `ApiKey ${config.public.esReadKey}`,
+        'Content-Type': 'application/json',
       },
-      {
-        [libguideIndex]: 1.3
-      }
-      ],
-      query: {
-        bool: {
-          must: [{
-            query_string: {
-              query: '(' +
+      method: 'POST',
+      body: JSON.stringify({
+        from,
+        indices_boost: [{
+          [libraryIndex]: 3.0
+        },
+        {
+          [libguideIndex]: 1.3
+        }
+        ],
+        query: {
+          bool: {
+            must: [{
+              query_string: {
+                query: '(' +
                 keyword +
                 ' AND NOT(sectionHandle:event)) OR (' +
                 keyword +
                 ' AND startDateWithTime:[now TO *] AND sectionHandle:event)',
-              fields: [
-                'title^4',
-                'summary^3',
-                'text^3',
-                'fullText^2',
-                'richText^2',
-                'sectionHandle',
-                'sectionHandleDisplayName'
-              ],
-              fuzziness: 'auto',
-            },
-          },],
-          filter: [...parseFilterQuerySiteSearch(queryFilters, configMapping)],
+                fields: [
+                  'title^4',
+                  'summary^3',
+                  'text^3',
+                  'fullText^2',
+                  'richText^2',
+                  'sectionHandle',
+                  'sectionHandleDisplayName'
+                ],
+                fuzziness: 'auto',
+              },
+            },],
+            filter: [...parseFilterQuerySiteSearch(queryFilters, configMapping)],
+          },
         },
-      },
-    }),
-  }
+      }),
+    }
   )
   const data = await response.json()
   return data
@@ -179,11 +179,11 @@ async function getMapping() {
     return
   const response = await fetch(
     `${config.public.esURL}/${config.public.esAlias}/_mapping`, {
-    headers: {
-      Authorization: `ApiKey ${config.public.esReadKey}`,
+      headers: {
+        Authorization: `ApiKey ${config.public.esReadKey}`,
       // 'Content-Type': 'application/x-www-form-urlencoded',
-    },
-  }
+      },
+    }
   )
   const data = await response.json()
   return data
@@ -195,21 +195,21 @@ async function getAggregationsForSiteSearch(fields) {
   if (!fields || fields.length === 0) return
   const response = await fetch(
     `${config.public.esURL}/${config.public.esAlias}/_search`, {
-    headers: {
-      Authorization: `ApiKey ${config.public.esReadKey}`,
-      'Content-Type': 'application/json',
-    },
-    method: 'POST',
-    body: JSON.stringify({
-      size: 0,
-      query: {
-        match_all: {},
+      headers: {
+        Authorization: `ApiKey ${config.public.esReadKey}`,
+        'Content-Type': 'application/json',
       },
-      aggs: {
-        ...parseFieldNames(fields),
-      },
-    }),
-  }
+      method: 'POST',
+      body: JSON.stringify({
+        size: 0,
+        query: {
+          match_all: {},
+        },
+        aggs: {
+          ...parseFieldNames(fields),
+        },
+      }),
+    }
   )
   const data = await response.json()
   return data.aggregations
@@ -221,24 +221,24 @@ async function getAggregations(fields, sectionHandle) {
   if (!fields || fields.length === 0) return
   const response = await fetch(
     `${config.public.esURL}/${config.public.esAlias}/_search`, {
-    headers: {
-      Authorization: `ApiKey ${config.public.esReadKey}`,
-      'Content-Type': 'application/json',
-    },
-    method: 'POST',
-    body: JSON.stringify({
-      size: 0,
-      query: {
-        query_string: {
-          query: sectionHandle,
-          default_field: 'sectionHandle'
+      headers: {
+        Authorization: `ApiKey ${config.public.esReadKey}`,
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+      body: JSON.stringify({
+        size: 0,
+        query: {
+          query_string: {
+            query: sectionHandle,
+            default_field: 'sectionHandle'
+          },
         },
-      },
-      aggs: {
-        ...parseFieldNames(fields),
-      },
-    }),
-  }
+        aggs: {
+          ...parseFieldNames(fields),
+        },
+      }),
+    }
   )
   const data = await response.json()
   return data.aggregations
@@ -297,11 +297,11 @@ async function keywordSearchWithFilters(
   // need to know fields to boost on for listing pages when searching like title etc
   const responseAlias = await fetch(
     `${config.public.esURL}/_alias/${config.public.esAlias}`, {
-    headers: {
-      Authorization: `ApiKey ${config.public.esReadKey}`,
-      'Content-Type': 'application/json',
-    },
-  }
+      headers: {
+        Authorization: `ApiKey ${config.public.esReadKey}`,
+        'Content-Type': 'application/json',
+      },
+    }
   )
   const dataAlias = await responseAlias.json()
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -81,7 +81,7 @@ export default defineNuxtConfig({
         })
 
         const postPages = await response.json()
-        // console.log('All pages', JSON.stringify(postPages.data.entries))
+        console.log('All pages', JSON.stringify(postPages))
         if (postPages && postPages.data && postPages.data.entries) {
           const postWithoutPayloadRoutes = postPages.data.entries.filter(item =>
             !item.sectionHandle.includes('meap') && !item.sectionHandle.includes('ftva')

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -48,11 +48,17 @@ export default defineNuxtConfig({
   nitro: {
     minify: false,
     prerender: {
-      crawlLinks: true,
+      crawlLinks: false,
       failOnError: false,
       concurrency: 50,
       interval: 1000,
-      // routes: ['/'],
+      routes: ['/', '/about/jobs/staff-academic-jobs/', '/about/news/',
+        '/about/polices/', '/about/programs/',
+        '/about/staff/', '/about/student-opportunities/', '/about/status-updates/',
+        '/collections/', '/collections/access/', '/collections/explore/',
+        '/give/endowments/', '/help/services-resources/', '/help/services-resources/ask-us/',
+        '/impact/', '/search-site/', '/visit/events-exhibition/', '/visit/location/'
+      ],
     },
     hooks: {
       'prerender:generate'(route) {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -81,7 +81,7 @@ export default defineNuxtConfig({
         })
 
         const postPages = await response.json()
-        console.log('All pages', JSON.stringify(postPages))
+        // console.log('All pages', JSON.stringify(postPages?.data?.entries))
         if (postPages && postPages.data && postPages.data.entries) {
           const postWithoutPayloadRoutes = postPages.data.entries.filter(item =>
             !item.sectionHandle.includes('meap') && !item.sectionHandle.includes('ftva')
@@ -136,7 +136,9 @@ export default defineNuxtConfig({
   routeRules: {
     '/impact/all': { redirect: '/about/reports' },
   },
-
+  features: {
+    inlineStyles: false,
+  },
   /*
      ** Required charset and viewport meta tags
      */

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -38,7 +38,7 @@ if (!data.value.entry) {
   })
 }
 
-if (data.value.entry.slug && import.meta.server) {
+if (data.value.entry.slug && import.meta.prerender) {
   const { index } = useIndexer()
   await index(data.value.entry, path.replaceAll('/', '--'))
 }

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -39,8 +39,8 @@ if (!data.value.entry) {
 }
 
 if (data.value.entry.slug && import.meta.server) {
-  const { $elasticsearchplugin } = useNuxtApp()
-  await $elasticsearchplugin.index(data.value.entry, path.replaceAll('/', '--'))
+  const { index } = useIndexer()
+  await index(data.value.entry, path.replaceAll('/', '--'))
 }
 
 const page = ref(_get(data.value, 'entry', {}))

--- a/pages/about/jobs/staff-academic-jobs/index.vue
+++ b/pages/about/jobs/staff-academic-jobs/index.vue
@@ -26,7 +26,7 @@ if (error.value) {
 if (!data.value.entry && !data.value.allJobs) {
   throw createError({ statusCode: 404, message: 'Page not found', fatal: true })
 }
-if (data.value.entry && import.meta.server) {
+if (data.value.entry && import.meta.prerender) {
   const { index } = useIndexer()
   const doc = {
     title: data.value.entry.title,

--- a/pages/about/jobs/staff-academic-jobs/index.vue
+++ b/pages/about/jobs/staff-academic-jobs/index.vue
@@ -27,7 +27,7 @@ if (!data.value.entry && !data.value.allJobs) {
   throw createError({ statusCode: 404, message: 'Page not found', fatal: true })
 }
 if (data.value.entry && import.meta.server) {
-  const { $elasticsearchplugin } = useNuxtApp()
+  const { index } = useIndexer()
   const doc = {
     title: data.value.entry.title,
     text: data.value.entry.text,
@@ -35,7 +35,7 @@ if (data.value.entry && import.meta.server) {
     phoneNumber: data.value.entry.phoneNumber,
     uri: 'about/jobs/staff-academic-jobs/'
   }
-  await $elasticsearchplugin.index(doc, 'job-opportunities-list')
+  await index(doc, 'job-opportunities-list')
 }
 const page = ref(_get(data.value, 'entry', {}))
 const allJobs = ref(_get(data.value, 'allJobs', {}))

--- a/pages/about/news/[slug].vue
+++ b/pages/about/news/[slug].vue
@@ -35,9 +35,9 @@ if (!data.value.entry) {
   })
 }
 
-// console.log("import.meta.server", import.meta.server, process.client)
+// console.log("import.meta.prerender", import.meta.prerender, process.client)
 
-if (data.value.entry.slug && import.meta.server) {
+if (data.value.entry.slug && import.meta.prerender) {
   // console.log('News slug article category:', data.value.entry.category)
   data.value.entry.articleCategory = data.value.entry.category
 

--- a/pages/about/news/[slug].vue
+++ b/pages/about/news/[slug].vue
@@ -41,9 +41,9 @@ if (data.value.entry.slug && import.meta.server) {
   // console.log('News slug article category:', data.value.entry.category)
   data.value.entry.articleCategory = data.value.entry.category
 
-  const { $elasticsearchplugin } = useNuxtApp()
-  // console.log("elasticsearchplugin", $elasticsearchplugin, data.value.entry.slug)
-  await $elasticsearchplugin?.index(data.value.entry, data.value.entry.slug)
+  const { index } = useIndexer()
+  // console.log("elasticsearchplugin", index, data.value.entry.slug)
+  await index(data.value.entry, data.value.entry.slug)
 }
 
 const page = ref(_get(data.value, 'entry', {}))

--- a/pages/about/news/index.vue
+++ b/pages/about/news/index.vue
@@ -35,7 +35,7 @@ if (!data.value?.entry && !data.value?.entries) {
   throw createError({ statusCode: 404, message: 'Page not found', fatal: true })
 }
 
-if (data.value.entry && import.meta.server) {
+if (data.value.entry && import.meta.prerender) {
   const { index } = useIndexer()
   const doc = {
     title: data.value.entry.title,

--- a/pages/about/news/index.vue
+++ b/pages/about/news/index.vue
@@ -338,7 +338,7 @@ onMounted(async () => {
         page.featuredNews.length > 0 &&
         hits.length === 0 &&
         !noResultsFound
-        "
+      "
       class="section-no-top-margin"
     >
       <BannerFeatured
@@ -354,12 +354,14 @@ onMounted(async () => {
         class="banner section-featured-banner"
       />
 
-      <DividerGeneral v-show="page &&
-        page.featuredNews &&
-        page.featuredNews.length &&
-        hits.length === 0 &&
-        !noResultsFound
-        " />
+      <DividerGeneral
+        v-show="page &&
+          page.featuredNews &&
+          page.featuredNews.length &&
+          hits.length === 0 &&
+          !noResultsFound
+        "
+      />
 
       <SectionTeaserHighlight
         v-show="parsedSectionHighlight.length > 0"
@@ -374,7 +376,7 @@ onMounted(async () => {
         page.featuredNews.length > 0 &&
         hits.length === 0 &&
         !noResultsFound
-        "
+      "
       theme="divider"
     >
       <DividerWayFinder color="about" />

--- a/pages/about/policies/[slug].vue
+++ b/pages/about/policies/[slug].vue
@@ -49,7 +49,7 @@ if (!data.value.entry) {
     statusMessage: 'Page Not Found'
   })
 }
-if (data.value.entry.slug && import.meta.server) {
+if (data.value.entry.slug && import.meta.prerender) {
   const { index } = useIndexer()
   await index(data.value.entry, route.params.slug)
 }

--- a/pages/about/policies/[slug].vue
+++ b/pages/about/policies/[slug].vue
@@ -11,7 +11,7 @@ import removeTags from '../utils/removeTags'
 // GQL
 import POLICY_DETAIL from '../gql/queries/PolicyDetail.gql'
 
-const { $graphql, $getHeaders, $elasticsearchplugin } = useNuxtApp()
+const { $graphql, $getHeaders } = useNuxtApp()
 const route = useRoute()
 const config = useRuntimeConfig()
 
@@ -50,7 +50,8 @@ if (!data.value.entry) {
   })
 }
 if (data.value.entry.slug && import.meta.server) {
-  await $elasticsearchplugin.index(data.value.entry, route.params.slug)
+  const { index } = useIndexer()
+  await index(data.value.entry, route.params.slug)
 }
 
 const page = ref(_get(data.value, 'entry', {}))

--- a/pages/about/policies/index.vue
+++ b/pages/about/policies/index.vue
@@ -34,13 +34,13 @@ if (!data.value.entry) {
 }
 
 if (data.value.entry && import.meta.server) {
-  const { $elasticsearchplugin } = useNuxtApp()
+  const { index } = useIndexer()
   const doc = {
     title: data.value.entry.title,
     text: data.value.entry.text,
     uri: 'about/policies/'
   }
-  await $elasticsearchplugin.index(doc, 'policy-listing')
+  await index(doc, 'policy-listing')
 }
 
 const page = ref(_get(data.value, 'entry', {}))

--- a/pages/about/policies/index.vue
+++ b/pages/about/policies/index.vue
@@ -33,7 +33,7 @@ if (!data.value.entry) {
   throw createError({ statusCode: 404, message: 'Page not found', fatal: true })
 }
 
-if (data.value.entry && import.meta.server) {
+if (data.value.entry && import.meta.prerender) {
   const { index } = useIndexer()
   const doc = {
     title: data.value.entry.title,

--- a/pages/about/programs/[slug].vue
+++ b/pages/about/programs/[slug].vue
@@ -179,7 +179,7 @@ onMounted(() => {
       <TheHours
         v-if="
           page.uri ==
-          'about/programs/campus-library-instructional-computing-commons-clicc'
+            'about/programs/campus-library-instructional-computing-commons-clicc'
         "
         :src="`${hostname}/blockCliccHours.html?lid=0`"
       />
@@ -187,7 +187,7 @@ onMounted(() => {
       <DividerWayFinder
         v-if="
           page.uri ==
-          'about/programs/campus-library-instructional-computing-commons-clicc'
+            'about/programs/campus-library-instructional-computing-commons-clicc'
         "
         class="divider"
         color="about"

--- a/pages/about/programs/[slug].vue
+++ b/pages/about/programs/[slug].vue
@@ -39,7 +39,7 @@ if (!data.value.entry) {
   throw createError({ statusCode: 404, message: 'Page not found', fatal: true })
 }
 
-if (data.value.entry.slug && import.meta.server) {
+if (data.value.entry.slug && import.meta.prerender) {
   const { index } = useIndexer()
   await index(data.value.entry, route.params.slug)
 }

--- a/pages/about/programs/[slug].vue
+++ b/pages/about/programs/[slug].vue
@@ -11,7 +11,7 @@ import removeTags from '../utils/removeTags'
 // GQL
 import PROGRAM_DETAIL from '../gql/queries/ProgramDetail.gql'
 
-const { $graphql, $getHeaders, $elasticsearchplugin } = useNuxtApp()
+const { $graphql, $getHeaders } = useNuxtApp()
 
 const route = useRoute()
 const hostname = ref('')
@@ -40,7 +40,8 @@ if (!data.value.entry) {
 }
 
 if (data.value.entry.slug && import.meta.server) {
-  await $elasticsearchplugin.index(data.value.entry, route.params.slug)
+  const { index } = useIndexer()
+  await index(data.value.entry, route.params.slug)
 }
 
 const page = ref(_get(data.value, 'entry', {}))
@@ -178,7 +179,7 @@ onMounted(() => {
       <TheHours
         v-if="
           page.uri ==
-            'about/programs/campus-library-instructional-computing-commons-clicc'
+          'about/programs/campus-library-instructional-computing-commons-clicc'
         "
         :src="`${hostname}/blockCliccHours.html?lid=0`"
       />
@@ -186,7 +187,7 @@ onMounted(() => {
       <DividerWayFinder
         v-if="
           page.uri ==
-            'about/programs/campus-library-instructional-computing-commons-clicc'
+          'about/programs/campus-library-instructional-computing-commons-clicc'
         "
         class="divider"
         color="about"

--- a/pages/about/programs/index.vue
+++ b/pages/about/programs/index.vue
@@ -16,7 +16,7 @@ import removeTags from '../utils/removeTags'
 import PROGRAMS_LIST from '../gql/queries/ProgramsList.gql'
 
 // GET DATA-
-const { $graphql, $dataApi } = useNuxtApp()
+const { $graphql } = useNuxtApp()
 const route = useRoute()
 
 const { data, error } = await useAsyncData('program-listing', async () => {
@@ -36,13 +36,13 @@ if (!data.value.entry && !data.value.entries) {
 }
 
 if (data.value.entry && import.meta.server) {
-  const { $elasticsearchplugin } = useNuxtApp()
+  const { index } = useIndexer()
   const doc = {
     title: data.value.entry.title,
     text: data.value.entry.text,
     uri: 'about/programs/'
   }
-  await $elasticsearchplugin.index(doc, 'program-listing')
+  await index(doc, 'program-listing')
 }
 // MAP DATA TO VARIABLES & WATCH
 const page = ref(_get(data.value, 'entry', {}))
@@ -83,7 +83,8 @@ async function searchES() {
       ))
   ) {
     const queryText = route.query?.q || '*'
-    const results = await $dataApi.keywordSearchWithFilters(
+    const { keywordSearchWithFilters } = useSearch()
+    const results = await keywordSearchWithFilters(
       queryText as string,
       config.programsList.searchFields,
       'sectionHandle:program',
@@ -209,7 +210,8 @@ function getSearchData(data) {
 }
 // fetch filters for the page from ES after page loads in Onmounted hook on the client side
 async function setFilters() {
-  const searchAggsResponse = await $dataApi.getAggregations(
+  const { getAggregations } = useSearch()
+  const searchAggsResponse = await getAggregations(
     config.programsList.filters,
     'program'
   )
@@ -253,7 +255,7 @@ onMounted(async () => {
         page.featuredPrograms.length &&
         hits.length == 0 &&
         !noResultsFound
-      "
+        "
       theme="divider"
     >
       <DividerWayFinder
@@ -268,7 +270,7 @@ onMounted(async () => {
         page.featuredPrograms.length &&
         hits.length == 0 &&
         !noResultsFound
-      "
+        "
       class="section-no-top-margin"
     >
       <BannerFeatured
@@ -301,7 +303,7 @@ onMounted(async () => {
         parsedProgramsList.length > 0 &&
         hits.length == 0 &&
         !noResultsFound
-      "
+        "
       section-title="All Programs & Initiatives"
     >
       <SectionStaffArticleList :items="parsedProgramsList" />

--- a/pages/about/programs/index.vue
+++ b/pages/about/programs/index.vue
@@ -255,7 +255,7 @@ onMounted(async () => {
         page.featuredPrograms.length &&
         hits.length == 0 &&
         !noResultsFound
-        "
+      "
       theme="divider"
     >
       <DividerWayFinder
@@ -270,7 +270,7 @@ onMounted(async () => {
         page.featuredPrograms.length &&
         hits.length == 0 &&
         !noResultsFound
-        "
+      "
       class="section-no-top-margin"
     >
       <BannerFeatured
@@ -303,7 +303,7 @@ onMounted(async () => {
         parsedProgramsList.length > 0 &&
         hits.length == 0 &&
         !noResultsFound
-        "
+      "
       section-title="All Programs & Initiatives"
     >
       <SectionStaffArticleList :items="parsedProgramsList" />

--- a/pages/about/programs/index.vue
+++ b/pages/about/programs/index.vue
@@ -35,7 +35,7 @@ if (!data.value.entry && !data.value.entries) {
   throw createError({ statusCode: 404, message: 'Page not found', fatal: true })
 }
 
-if (data.value.entry && import.meta.server) {
+if (data.value.entry && import.meta.prerender) {
   const { index } = useIndexer()
   const doc = {
     title: data.value.entry.title,

--- a/pages/about/reports/index.vue
+++ b/pages/about/reports/index.vue
@@ -25,13 +25,13 @@ if (!page.value.entry) {
 }
 
 if (page.value.entry && import.meta.server) {
-  const { $elasticsearchplugin } = useNuxtApp()
+  const { index } = useIndexer()
   const doc = {
     title: page.value.entry.title,
     text: page.value.entry.summary,
     uri: 'about/reports/'
   }
-  await $elasticsearchplugin.index(doc, 'impact-report-all-list')
+  await index(doc, 'impact-report-all-list')
 }
 
 useHead({

--- a/pages/about/reports/index.vue
+++ b/pages/about/reports/index.vue
@@ -24,7 +24,7 @@ if (!page.value.entry) {
   throw createError({ statusCode: 404, message: 'Page not found', fatal: true })
 }
 
-if (page.value.entry && import.meta.server) {
+if (page.value.entry && import.meta.prerender) {
   const { index } = useIndexer()
   const doc = {
     title: page.value.entry.title,

--- a/pages/about/staff/[slug].vue
+++ b/pages/about/staff/[slug].vue
@@ -10,7 +10,7 @@ import removeTags from '../utils/removeTags'
 import STAFF_DETAIL from '../gql/queries/StaffDetail.gql'
 
 const route = useRoute()
-const { $graphql, $elasticsearchplugin } = useNuxtApp()
+const { $graphql } = useNuxtApp()
 
 // ASYNC DATA into PAGE const
 const { data, error } = await useAsyncData(`staff/${route.params.slug}`, async () => {
@@ -34,9 +34,9 @@ if (!data.value.entry) {
 }
 // ES Index
 if (route.params.slug && import.meta.server) {
-  const { $elasticsearchplugin } = useNuxtApp()
-  // console.log("elasticsearchplugin", $elasticsearchplugin, route.params.slug)
-  await $elasticsearchplugin?.index(data.value.entry, route.params.slug)
+  const { index } = useIndexer()
+  // console.log("elasticsearchplugin", index, route.params.slug)
+  await index(data.value.entry, route.params.slug)
 }
 
 const page = ref(_get(data.value, 'entry', {}))

--- a/pages/about/staff/[slug].vue
+++ b/pages/about/staff/[slug].vue
@@ -33,7 +33,7 @@ if (!data.value.entry) {
   })
 }
 // ES Index
-if (route.params.slug && import.meta.server) {
+if (route.params.slug && import.meta.prerender) {
   const { index } = useIndexer()
   // console.log("elasticsearchplugin", index, route.params.slug)
   await index(data.value.entry, route.params.slug)

--- a/pages/about/staff/index.vue
+++ b/pages/about/staff/index.vue
@@ -173,9 +173,9 @@ async function searchES() {
     }
     const { 'subjectLibrarian.keyword': subjectLibrarianKeyword, ...filters } = routeFilters.value
     const extrafilters = (subjectLibrarianKeyword && subjectLibrarianKeyword.length > 0 && subjectLibrarianKeyword[0] === 'yes') ?
-      [
-        { term: { 'subjectLibrarian.keyword': 'yes' } }
-      ]
+        [
+          { term: { 'subjectLibrarian.keyword': 'yes' } }
+        ]
       : []
 
     // console.log('in router query in asyc data queryText', queryText)
@@ -408,9 +408,9 @@ onMounted(async () => {
             'subjectLibrarian.keyword'
           ][0] === '')) ||
           !searchGenericQuery.queryFilters[
-          'subjectLibrarian.keyword'
+            'subjectLibrarian.keyword'
           ])
-        "
+      "
       class="section-no-top-margin"
     >
       <AlphabeticalBrowseBy
@@ -471,7 +471,7 @@ onMounted(async () => {
         searchGenericQuery.queryFilters['subjectLibrarian.keyword'][0] ===
         'yes' &&
         groupByAcademicLibraries
-        "
+      "
       class="section-no-top-margin"
     >
       <h3 class="section-title subject-librarian">

--- a/pages/about/staff/index.vue
+++ b/pages/about/staff/index.vue
@@ -30,7 +30,7 @@ if (!data.value.entry && !data.value.entries) {
   throw createError({ statusCode: 404, message: 'Page not found', fatal: true })
 }
 
-if (data.value.entry && import.meta.server) {
+if (data.value.entry && import.meta.prerender) {
   const { index } = useIndexer()
   const doc = {
     title: data.value.entry.title,

--- a/pages/about/student-opportunities/index.vue
+++ b/pages/about/student-opportunities/index.vue
@@ -138,8 +138,8 @@ const parsedAssociatedTopics = computed(() => {
     <BannerText
       v-if="
         page.buttonUrl &&
-        page.buttonUrl[0] &&
-        page.buttonUrl[0].buttonText
+          page.buttonUrl[0] &&
+          page.buttonUrl[0].buttonText
       "
       class="banner-text"
       :title="page.title"

--- a/pages/about/student-opportunities/index.vue
+++ b/pages/about/student-opportunities/index.vue
@@ -29,7 +29,7 @@ if (!data.value.entry && !data.value.allJobs) {
 }
 
 if (data.value.entry && import.meta.server) {
-  const { $elasticsearchplugin } = useNuxtApp()
+  const { index } = useIndexer()
   const doc = {
     title: data.value.entry.title,
     text: data.value.entry.text,
@@ -37,7 +37,7 @@ if (data.value.entry && import.meta.server) {
     phoneNumber: data.value.entry.phoneNumber,
     uri: 'about/student-opportunities/'
   }
-  await $elasticsearchplugin.index(doc, 'student-opportunities-list')
+  await index(doc, 'student-opportunities-list')
 }
 
 const page = ref(_get(data.value, 'entry', {}))
@@ -138,8 +138,8 @@ const parsedAssociatedTopics = computed(() => {
     <BannerText
       v-if="
         page.buttonUrl &&
-          page.buttonUrl[0] &&
-          page.buttonUrl[0].buttonText
+        page.buttonUrl[0] &&
+        page.buttonUrl[0].buttonText
       "
       class="banner-text"
       :title="page.title"

--- a/pages/about/student-opportunities/index.vue
+++ b/pages/about/student-opportunities/index.vue
@@ -28,7 +28,7 @@ if (!data.value.entry && !data.value.allJobs) {
   throw createError({ statusCode: 404, message: 'Page not found', fatal: true })
 }
 
-if (data.value.entry && import.meta.server) {
+if (data.value.entry && import.meta.prerender) {
   const { index } = useIndexer()
   const doc = {
     title: data.value.entry.title,

--- a/pages/collections/access/index.vue
+++ b/pages/collections/access/index.vue
@@ -53,6 +53,7 @@ if (
   data.value.entry.accessCollections.length > 0 &&
   import.meta.prerender
 ) {
+  const { index } = useIndexer()
   for (const collection of data.value.entry.accessCollections) {
     collection.searchType = 'accessCollections'
     collection.to = collection.uri
@@ -226,10 +227,8 @@ function getSearchData(data) {
       <DividerWayFinder class="search-margin" />
     </SectionWrapper>
 
-    <SectionWrapper
-      v-show="page && page.accessCollections && hits.length == 0 && !noResultsFound
-      "
-    >
+    <SectionWrapper v-show="page && page.accessCollections && hits.length == 0 && !noResultsFound
+      ">
       <SectionCardsWithIllustrations
         class="section"
         :items="parsedAccessCollections"

--- a/pages/collections/access/index.vue
+++ b/pages/collections/access/index.vue
@@ -226,8 +226,10 @@ function getSearchData(data) {
       <DividerWayFinder class="search-margin" />
     </SectionWrapper>
 
-    <SectionWrapper v-show="page && page.accessCollections && hits.length == 0 && !noResultsFound
-      ">
+    <SectionWrapper
+      v-show="page && page.accessCollections && hits.length == 0 && !noResultsFound
+      "
+    >
       <SectionCardsWithIllustrations
         class="section"
         :items="parsedAccessCollections"

--- a/pages/collections/access/index.vue
+++ b/pages/collections/access/index.vue
@@ -36,7 +36,7 @@ if (!data.value.entry) {
   throw createError({ statusCode: 404, message: 'Page not found', fatal: true })
 }
 
-if (data.value.entry && import.meta.server) {
+if (data.value.entry && import.meta.prerender) {
   const { index } = useIndexer()
   const doc = {
     title: data.value.entry.title,
@@ -51,7 +51,7 @@ if (data.value.entry && import.meta.server) {
 if (
   data.value.entry.accessCollections &&
   data.value.entry.accessCollections.length > 0 &&
-  import.meta.server
+  import.meta.prerender
 ) {
   for (const collection of data.value.entry.accessCollections) {
     collection.searchType = 'accessCollections'

--- a/pages/collections/access/index.vue
+++ b/pages/collections/access/index.vue
@@ -11,7 +11,7 @@ import ACCESS_COLLECTIONS from '../gql/queries/CollectionsAccessList.gql'
 
 // UTILITIES & PLUGINS
 import config from '../utils/searchConfig'
-const { $graphql, $elasticsearchplugin, $dataApi } = useNuxtApp()
+const { $graphql } = useNuxtApp()
 
 // ROUTING
 const route = useRoute()
@@ -37,13 +37,13 @@ if (!data.value.entry) {
 }
 
 if (data.value.entry && import.meta.server) {
-  const { $elasticsearchplugin } = useNuxtApp()
+  const { index } = useIndexer()
   const doc = {
     title: data.value.entry.title,
     text: data.value.entry.text,
     uri: 'collections/access/'
   }
-  await $elasticsearchplugin.index(doc, 'access-collection')
+  await index(doc, 'access-collection')
 }
 
 // only index on server
@@ -59,7 +59,7 @@ if (
       ? collection.uri
       : collection.externalResourceUrl
     // console.log('Index Access collections:', collection.slug)
-    await $elasticsearchplugin.index(collection, collection.slug)
+    await index(collection, collection.slug)
   }
 }
 // end indexing
@@ -86,7 +86,8 @@ async function searchES() {
   if (route?.query && route?.query.q && route?.query.q !== '') {
     // console.log('searchES', route.query.q)
     const queryText = route.query.q || '*'
-    const results = await $dataApi.keywordSearchWithFilters(
+    const { keywordSearchWithFilters } = useSearch()
+    const results = await keywordSearchWithFilters(
       queryText,
       config.accessCollections.searchFields,
       'searchType:accessCollection',
@@ -225,10 +226,8 @@ function getSearchData(data) {
       <DividerWayFinder class="search-margin" />
     </SectionWrapper>
 
-    <SectionWrapper
-      v-show="page && page.accessCollections && hits.length == 0 && !noResultsFound
-      "
-    >
+    <SectionWrapper v-show="page && page.accessCollections && hits.length == 0 && !noResultsFound
+      ">
       <SectionCardsWithIllustrations
         class="section"
         :items="parsedAccessCollections"

--- a/pages/collections/explore/[slug].vue
+++ b/pages/collections/explore/[slug].vue
@@ -34,7 +34,7 @@ if (!data.value.entry) {
   throw createError({ statusCode: 404, message: 'Page not found', fatal: true })
 }
 
-if (data.value.entry.slug && import.meta.server) {
+if (data.value.entry.slug && import.meta.prerender) {
   const { index } = useIndexer()
   await index(data.value.entry, route.params.slug)
 }

--- a/pages/collections/explore/[slug].vue
+++ b/pages/collections/explore/[slug].vue
@@ -12,7 +12,7 @@ import removeTags from '../utils/removeTags'
 // GQL
 import COLLECTION_DETAIL from '../gql/queries/CollectionDetail.gql'
 
-const { $graphql, $getHeaders, $elasticsearchplugin } = useNuxtApp()
+const { $graphql, $getHeaders } = useNuxtApp()
 
 const route = useRoute()
 
@@ -35,7 +35,8 @@ if (!data.value.entry) {
 }
 
 if (data.value.entry.slug && import.meta.server) {
-  await $elasticsearchplugin.index(data.value.entry, route.params.slug)
+  const { index } = useIndexer()
+  await index(data.value.entry, route.params.slug)
 }
 
 const page = ref(_get(data.value, 'entry', {}))
@@ -230,8 +231,8 @@ onMounted(() => {
     <SectionWrapper
       v-if="
         parsedServicesAndResources.length > 0 ||
-          parsedEndowments.length > 0 ||
-          parsedAssociatedStaffMember.length > 0
+        parsedEndowments.length > 0 ||
+        parsedAssociatedStaffMember.length > 0
       "
       theme="divider"
     >
@@ -254,7 +255,7 @@ onMounted(() => {
       <DividerWayFinder
         v-if="
           parsedEndowments.length > 0 ||
-            parsedAssociatedStaffMember.length > 0
+          parsedAssociatedStaffMember.length > 0
         "
         class="divider-way-finder"
         color="default"

--- a/pages/collections/explore/[slug].vue
+++ b/pages/collections/explore/[slug].vue
@@ -231,8 +231,8 @@ onMounted(() => {
     <SectionWrapper
       v-if="
         parsedServicesAndResources.length > 0 ||
-        parsedEndowments.length > 0 ||
-        parsedAssociatedStaffMember.length > 0
+          parsedEndowments.length > 0 ||
+          parsedAssociatedStaffMember.length > 0
       "
       theme="divider"
     >
@@ -255,7 +255,7 @@ onMounted(() => {
       <DividerWayFinder
         v-if="
           parsedEndowments.length > 0 ||
-          parsedAssociatedStaffMember.length > 0
+            parsedAssociatedStaffMember.length > 0
         "
         class="divider-way-finder"
         color="default"

--- a/pages/collections/explore/index.vue
+++ b/pages/collections/explore/index.vue
@@ -263,7 +263,7 @@ onMounted(async () => {
         parsedCollectionList.length &&
         hits.length == 0 &&
         !noResultsFound
-        "
+      "
       class="section-no-top-margin"
     >
       <SectionTeaserCard :items="parsedCollectionList" />

--- a/pages/collections/explore/index.vue
+++ b/pages/collections/explore/index.vue
@@ -43,7 +43,7 @@ if (!data.value.entry) {
   throw createError({ statusCode: 404, message: 'Page not found', fatal: true })
 }
 
-if (data.value.entry && import.meta.server) {
+if (data.value.entry && import.meta.prerender) {
   const { index } = useIndexer()
   const doc = {
     title: data.value.entry.title,

--- a/pages/collections/explore/index.vue
+++ b/pages/collections/explore/index.vue
@@ -17,7 +17,7 @@ import config from '../utils/searchConfig'
 import queryFilterHasValues from '../utils/queryFilterHasValues'
 import parseFilters from '../utils/parseFilters'
 
-const { $graphql, $dataApi } = useNuxtApp()
+const { $graphql } = useNuxtApp()
 
 // ROUTING
 const route = useRoute()
@@ -44,13 +44,13 @@ if (!data.value.entry) {
 }
 
 if (data.value.entry && import.meta.server) {
-  const { $elasticsearchplugin } = useNuxtApp()
+  const { index } = useIndexer()
   const doc = {
     title: data.value.entry.title,
     text: data.value.entry.text,
     uri: 'collections/explore/'
   }
-  await $elasticsearchplugin.index(doc, 'explore-collection')
+  await index(doc, 'explore-collection')
 }
 
 // DATA
@@ -136,7 +136,8 @@ async function searchES() {
   ) {
     // console.log('Search ES HITS query,', route.query.q)
     const queryText = route.query.q || '*'
-    const results = await $dataApi.keywordSearchWithFilters(
+    const { keywordSearchWithFilters } = useSearch()
+    const results = await keywordSearchWithFilters(
       queryText,
       config.exploreCollection.searchFields,
       'sectionHandle:collection',
@@ -203,7 +204,8 @@ function getSearchData(data) {
 
 // fetch filters for the page from ES after page loads in Onmounted hook on the client side
 async function setFilters() {
-  const searchAggsResponse = await $dataApi.getAggregations(
+  const { getAggregations } = useSearch()
+  const searchAggsResponse = await getAggregations(
     config.exploreCollection.filters,
     'collection'
   )
@@ -261,7 +263,7 @@ onMounted(async () => {
         parsedCollectionList.length &&
         hits.length == 0 &&
         !noResultsFound
-      "
+        "
       class="section-no-top-margin"
     >
       <SectionTeaserCard :items="parsedCollectionList" />

--- a/pages/collections/index.vue
+++ b/pages/collections/index.vue
@@ -28,7 +28,7 @@ if (error.value) {
 if (!data.value.data.entry && !data.value.data.entries) {
   throw createError({ statusCode: 404, message: 'Page not found', fatal: true })
 }
-if (data.value.entry && import.meta.server) {
+if (data.value.entry && import.meta.prerender) {
   const { index } = useIndexer()
   const doc = {
     title: data.value.entry.title,

--- a/pages/collections/index.vue
+++ b/pages/collections/index.vue
@@ -29,13 +29,13 @@ if (!data.value.data.entry && !data.value.data.entries) {
   throw createError({ statusCode: 404, message: 'Page not found', fatal: true })
 }
 if (data.value.entry && import.meta.server) {
-  const { $elasticsearchplugin } = useNuxtApp()
+  const { index } = useIndexer()
   const doc = {
     title: data.value.entry.title,
     text: data.value.entry.text,
     uri: 'collections/'
   }
-  await $elasticsearchplugin.index(doc, 'collections-list')
+  await index(doc, 'collections-list')
 }
 
 const page = ref(_get(data.value.data, 'entry', {}))

--- a/pages/give/endowments/[slug].vue
+++ b/pages/give/endowments/[slug].vue
@@ -156,12 +156,12 @@ function computeDonors(donors) {
         page.alternativeName[0] &&
         page.alternativeName[0].fullName) ||
         ''
-        "
+      "
       :language="(page.alternativeName &&
         page.alternativeName[0] &&
         page.alternativeName[0].languageAltName) ||
         ''
-        "
+      "
       button-text="Give Now"
       :to="page.to"
     />
@@ -194,7 +194,7 @@ function computeDonors(donors) {
           <ul v-if="parsedAssociatedLocations.length > 0">
             <li
               v-for="(
-location, index
+                location, index
               ) in parsedAssociatedLocations"
               :key="`AssociatedLocation-${location}-${index}`"
             >

--- a/pages/give/endowments/[slug].vue
+++ b/pages/give/endowments/[slug].vue
@@ -37,10 +37,10 @@ if (!data.value.entry) {
 }
 
 if (data.value.entry.slug && import.meta.server) {
-  const { $elasticsearchplugin } = useNuxtApp()
-  // console.log("elasticsearchplugin", $elasticsearchplugin, data.value.entry.slug)
+  const { index } = useIndexer()
+  // console.log("elasticsearchplugin", index, data.value.entry.slug)
   data.value.entry.donorNames = parsedDonorsForES(data.value.entry.donors)
-  await $elasticsearchplugin?.index(data.value.entry, data.value.entry.slug)
+  await index(data.value.entry, data.value.entry.slug)
 }
 // console.log("data.value.entry", data.value.entry)
 
@@ -156,12 +156,12 @@ function computeDonors(donors) {
         page.alternativeName[0] &&
         page.alternativeName[0].fullName) ||
         ''
-      "
+        "
       :language="(page.alternativeName &&
         page.alternativeName[0] &&
         page.alternativeName[0].languageAltName) ||
         ''
-      "
+        "
       button-text="Give Now"
       :to="page.to"
     />
@@ -194,7 +194,7 @@ function computeDonors(donors) {
           <ul v-if="parsedAssociatedLocations.length > 0">
             <li
               v-for="(
-                location, index
+location, index
               ) in parsedAssociatedLocations"
               :key="`AssociatedLocation-${location}-${index}`"
             >

--- a/pages/give/endowments/[slug].vue
+++ b/pages/give/endowments/[slug].vue
@@ -36,7 +36,7 @@ if (!data.value.entry) {
   })
 }
 
-if (data.value.entry.slug && import.meta.server) {
+if (data.value.entry.slug && import.meta.prerender) {
   const { index } = useIndexer()
   // console.log("elasticsearchplugin", index, data.value.entry.slug)
   data.value.entry.donorNames = parsedDonorsForES(data.value.entry.donors)

--- a/pages/give/endowments/index.vue
+++ b/pages/give/endowments/index.vue
@@ -31,7 +31,7 @@ if (!data.value?.data || !data.value?.data?.entry || !data.value?.data?.entries)
   throw createError({ statusCode: 404, message: 'Page not found', fatal: true })
 }
 
-if (data.value?.data?.entry && import.meta.server) {
+if (data.value?.data?.entry && import.meta.prerender) {
   const { index } = useIndexer()
   const doc = {
     title: data.value.data.entry.title,

--- a/pages/give/endowments/index.vue
+++ b/pages/give/endowments/index.vue
@@ -131,12 +131,12 @@ const searchGenericQuery = ref({
 
 watch(() =>
   route.query,
-  (newVal, oldVal) => {
-    // console.log('ES newVal, oldVal', newVal, oldVal)
-    searchGenericQuery.value.queryText = route.query.q || ''
-    searchGenericQuery.value.queryFilters = parseFilters(route.query.filters || '')
-    searchES()
-  }, { deep: true, immediate: true }
+(newVal, oldVal) => {
+  // console.log('ES newVal, oldVal', newVal, oldVal)
+  searchGenericQuery.value.queryText = route.query.q || ''
+  searchGenericQuery.value.queryFilters = parseFilters(route.query.filters || '')
+  searchES()
+}, { deep: true, immediate: true }
 )
 
 async function searchES() {
@@ -278,7 +278,7 @@ onMounted(async () => {
         parsedFeaturedEndowments.length &&
         hits.length == 0 &&
         !noResultsFound
-        "
+      "
       class="section-no-top-margin"
       :section-title="page.featuredEndowments[0].titleGeneral"
       :section-summary="page.featuredEndowments[0].sectionSummary"
@@ -296,7 +296,7 @@ onMounted(async () => {
         parsedFeaturedEndowments.length &&
         hits.length == 0 &&
         !noResultsFound
-        "
+      "
       theme="divider"
     >
       <DividerWayFinder color="about" />
@@ -308,7 +308,7 @@ onMounted(async () => {
         parsedEndowmentsList.length &&
         hits.length == 0 &&
         !noResultsFound
-        "
+      "
       section-title="All Collection Endowments"
     >
       <SectionGenericList :items="parsedEndowmentsList" />

--- a/pages/help/[slug].vue
+++ b/pages/help/[slug].vue
@@ -34,9 +34,9 @@ if (!data.value.entry) {
 }
 
 if (route.params.slug !== undefined && data.value.entry.slug && import.meta.server) {
-  const { $elasticsearchplugin } = useNuxtApp()
+  const { index } = useIndexer()
   // console.log('data.value.entry.serviceOrResourceType', data.value.entry.serviceOrResourceType)
-  await $elasticsearchplugin?.index(data.value.entry, data.value.entry.slug)
+  await index(data.value.entry, data.value.entry.slug)
 }
 
 if (data.value.entry) {

--- a/pages/help/[slug].vue
+++ b/pages/help/[slug].vue
@@ -33,7 +33,7 @@ if (!data.value.entry) {
   throw createError({ statusCode: 404, message: 'Page not found', fatal: true })
 }
 
-if (route.params.slug !== undefined && data.value.entry.slug && import.meta.server) {
+if (route.params.slug !== undefined && data.value.entry.slug && import.meta.prerender) {
   const { index } = useIndexer()
   // console.log('data.value.entry.serviceOrResourceType', data.value.entry.serviceOrResourceType)
   await index(data.value.entry, data.value.entry.slug)

--- a/pages/help/services-resources/[slug].vue
+++ b/pages/help/services-resources/[slug].vue
@@ -190,9 +190,9 @@ onMounted(() => {
       <BannerText
         v-if="
           !page.serviceOrResource.heroImage ||
-          page.serviceOrResource.heroImage.length == 0 ||
-          !page.serviceOrResource.heroImage[0].image ||
-          page.serviceOrResource.heroImage[0].image.length == 0
+            page.serviceOrResource.heroImage.length == 0 ||
+            !page.serviceOrResource.heroImage[0].image ||
+            page.serviceOrResource.heroImage[0].image.length == 0
         "
         class="banner-text"
         :category="page.serviceOrResource.type"
@@ -205,9 +205,9 @@ onMounted(() => {
       <SectionWrapper
         v-if="
           page.serviceOrResource.heroImage &&
-          page.serviceOrResource.heroImage.length == 1 &&
-          page.serviceOrResource.heroImage[0].image &&
-          page.serviceOrResource.heroImage[0].image.length > 0
+            page.serviceOrResource.heroImage.length == 1 &&
+            page.serviceOrResource.heroImage[0].image &&
+            page.serviceOrResource.heroImage[0].image.length > 0
         "
         class="section-banner"
       >
@@ -282,9 +282,9 @@ onMounted(() => {
       <BannerText
         v-if="
           page.workshopSeries &&
-          (page.workshopSeries.image.length == 0 ||
-            !page.workshopSeries.image[0].image ||
-            page.workshopSeries.image[0].image.length == 0)
+            (page.workshopSeries.image.length == 0 ||
+              !page.workshopSeries.image[0].image ||
+              page.workshopSeries.image[0].image.length == 0)
         "
         :title="page.workshopSeries.title"
         :text="page.workshopSeries.summary"
@@ -297,9 +297,9 @@ onMounted(() => {
       <SectionWrapper
         v-if="
           page.workshopSeries.image &&
-          page.workshopSeries.image.length == 1 &&
-          page.workshopSeries.image[0].image &&
-          page.workshopSeries.image[0].image.length > 0
+            page.workshopSeries.image.length == 1 &&
+            page.workshopSeries.image[0].image &&
+            page.workshopSeries.image[0].image.length > 0
         "
         class="section-banner"
       >

--- a/pages/help/services-resources/[slug].vue
+++ b/pages/help/services-resources/[slug].vue
@@ -30,7 +30,7 @@ if (!data.value.serviceOrResource && !data.value.workshopSeries) {
   throw createError({ statusCode: 404, message: 'Page not found', fatal: true })
 }
 
-if (import.meta.server) {
+if (import.meta.prerender) {
   const { index } = useIndexer()
   if (data.value.workshopSeries) {
     data.value.workshopSeries.sectionHandle = 'workshopSeries'

--- a/pages/help/services-resources/[slug].vue
+++ b/pages/help/services-resources/[slug].vue
@@ -31,12 +31,12 @@ if (!data.value.serviceOrResource && !data.value.workshopSeries) {
 }
 
 if (import.meta.server) {
-  const { $elasticsearchplugin } = useNuxtApp()
+  const { index } = useIndexer()
   if (data.value.workshopSeries) {
     data.value.workshopSeries.sectionHandle = 'workshopSeries'
     data.value.workshopSeries.serviceOrResourceType = 'workshop series'
   }
-  await $elasticsearchplugin?.index(data.value.serviceOrResource || data.value.workshopSeries, route.params.slug)
+  await index(data.value.serviceOrResource || data.value.workshopSeries, route.params.slug)
 }
 
 const page = ref(data.value)
@@ -190,9 +190,9 @@ onMounted(() => {
       <BannerText
         v-if="
           !page.serviceOrResource.heroImage ||
-            page.serviceOrResource.heroImage.length == 0 ||
-            !page.serviceOrResource.heroImage[0].image ||
-            page.serviceOrResource.heroImage[0].image.length == 0
+          page.serviceOrResource.heroImage.length == 0 ||
+          !page.serviceOrResource.heroImage[0].image ||
+          page.serviceOrResource.heroImage[0].image.length == 0
         "
         class="banner-text"
         :category="page.serviceOrResource.type"
@@ -205,9 +205,9 @@ onMounted(() => {
       <SectionWrapper
         v-if="
           page.serviceOrResource.heroImage &&
-            page.serviceOrResource.heroImage.length == 1 &&
-            page.serviceOrResource.heroImage[0].image &&
-            page.serviceOrResource.heroImage[0].image.length > 0
+          page.serviceOrResource.heroImage.length == 1 &&
+          page.serviceOrResource.heroImage[0].image &&
+          page.serviceOrResource.heroImage[0].image.length > 0
         "
         class="section-banner"
       >
@@ -282,9 +282,9 @@ onMounted(() => {
       <BannerText
         v-if="
           page.workshopSeries &&
-            (page.workshopSeries.image.length == 0 ||
-              !page.workshopSeries.image[0].image ||
-              page.workshopSeries.image[0].image.length == 0)
+          (page.workshopSeries.image.length == 0 ||
+            !page.workshopSeries.image[0].image ||
+            page.workshopSeries.image[0].image.length == 0)
         "
         :title="page.workshopSeries.title"
         :text="page.workshopSeries.summary"
@@ -297,9 +297,9 @@ onMounted(() => {
       <SectionWrapper
         v-if="
           page.workshopSeries.image &&
-            page.workshopSeries.image.length == 1 &&
-            page.workshopSeries.image[0].image &&
-            page.workshopSeries.image[0].image.length > 0
+          page.workshopSeries.image.length == 1 &&
+          page.workshopSeries.image[0].image &&
+          page.workshopSeries.image[0].image.length > 0
         "
         class="section-banner"
       >

--- a/pages/help/services-resources/ask-us/index.vue
+++ b/pages/help/services-resources/ask-us/index.vue
@@ -28,13 +28,13 @@ if (!data.value.entry) {
 }
 
 if (data.value.entry && import.meta.server) {
-  const { $elasticsearchplugin } = useNuxtApp()
+  const { index } = useIndexer()
   const doc = {
     title: data.value.entry.title,
     text: data.value.entry.summary,
     uri: 'help/'
   }
-  await $elasticsearchplugin.index(doc, 'ask-us')
+  await index(doc, 'ask-us')
 }
 
 const page = ref(_get(data.value, 'entry', {}))

--- a/pages/help/services-resources/ask-us/index.vue
+++ b/pages/help/services-resources/ask-us/index.vue
@@ -27,7 +27,7 @@ if (!data.value.entry) {
   throw createError({ statusCode: 404, message: 'Page not found', fatal: true })
 }
 
-if (data.value.entry && import.meta.server) {
+if (data.value.entry && import.meta.prerender) {
   const { index } = useIndexer()
   const doc = {
     title: data.value.entry.title,

--- a/pages/help/services-resources/index.vue
+++ b/pages/help/services-resources/index.vue
@@ -21,7 +21,7 @@ import sortByTitle from '../utils/sortByTitle'
 import SERVICE_RESOURCE_WORKSHOPSERIES_LIST from '../gql/queries/ServiceResourceWorkshopSeriesList.gql'
 import HELP_TOPIC_LIST from '../gql/queries/HelpTopicList.gql'
 
-const { $graphql, $elasticsearchplugin, $dataApi } = useNuxtApp()
+const { $graphql } = useNuxtApp()
 const route = useRoute()
 
 const { data, error } = await useAsyncData('services-resources-list', async () => {
@@ -50,8 +50,9 @@ if (
   data.value.data.externalResource.length > 0 &&
   import.meta.server
 ) {
+  const { index } = useIndexer()
   for (const externalResource of data.value.data.externalResource) {
-    await $elasticsearchplugin.index(
+    await index(
       { ...externalResource, serviceOrResourceType: 'external resource' },
       externalResource.slug
     )
@@ -59,13 +60,13 @@ if (
 }
 
 if (data.value.entry && import.meta.server) {
-  const { $elasticsearchplugin } = useNuxtApp()
+  const { index } = useIndexer()
   const doc = {
     title: data.value.entry.title,
     text: data.value.entry.text,
     uri: 'help/services-resources/'
   }
-  await $elasticsearchplugin.index(doc, 'services-resources-list')
+  await index(doc, 'services-resources-list')
 }
 
 const page = ref(data.value.data)
@@ -114,7 +115,8 @@ async function searchES() {
   ) {
     // console.log('Search ES HITS query,', route.query.q)
     const queryText = route.query.q || '*'
-    const results = await $dataApi.keywordSearchWithFilters(
+    const { keywordSearchWithFilters } = useSearch()
+    const results = await keywordSearchWithFilters(
       queryText,
       config.serviceOrResources.searchFields,
       '(sectionHandle:serviceOrResource OR sectionHandle:workshopSeries OR sectionHandle:helpTopic) OR (sectionHandle:externalResource AND displayEntry:yes)',
@@ -250,7 +252,8 @@ onMounted(async () => {
 // ELEASTIC SEARCH METHODS
 // FETCH FILTERS FROM ES
 async function setFilters() {
-  const searchAggsResponse = await $dataApi.getAggregations(
+  const { getAggregations } = useSearch()
+  const searchAggsResponse = await getAggregations(
     config.serviceOrResources.filters,
     'serviceOrResource OR workshopSeries OR helpTopic OR externalResource',
   )

--- a/pages/help/services-resources/index.vue
+++ b/pages/help/services-resources/index.vue
@@ -43,23 +43,23 @@ if (!data.value.data && !data.value.helpTopicData) {
 // ELASTIC SEARCH INDEX
 // GETS DATA FROM CRAFT
 // CREATES ES INDEX TO BE SEARCHED
-// CHECK THAT NUXT IS RUNNING ON THE SERVER (import.meta.server)
+// CHECK THAT NUXT IS RUNNING ON THE SERVER (import.meta.prerender)
 // console.log('DATA-DATA-DATA-DATA' + data)
 if (
   data.value.data.externalResource &&
   data.value.data.externalResource.length > 0 &&
-  import.meta.server
+  import.meta.prerender
 ) {
   const { index } = useIndexer()
   for (const externalResource of data.value.data.externalResource) {
     await index(
-      { ...externalResource, serviceOrResourceType: 'external resource' },
+      { ...externalResource, serviceOrResourceType: 'resource' },
       externalResource.slug
     )
   }
 }
 
-if (data.value.entry && import.meta.server) {
+if (data.value.entry && import.meta.prerender) {
   const { index } = useIndexer()
   const doc = {
     title: data.value.entry.title,

--- a/pages/impact/[year]/[slug].vue
+++ b/pages/impact/[year]/[slug].vue
@@ -31,7 +31,7 @@ if (!data.value.entry) {
   })
 }
 
-if (data.value.entry.slug && import.meta.server) {
+if (data.value.entry.slug && import.meta.prerender) {
   const { index } = useIndexer()
   await index(data.value.entry, data.value.entry.slug)
 }

--- a/pages/impact/[year]/[slug].vue
+++ b/pages/impact/[year]/[slug].vue
@@ -32,8 +32,8 @@ if (!data.value.entry) {
 }
 
 if (data.value.entry.slug && import.meta.server) {
-  const { $elasticsearchplugin } = useNuxtApp()
-  await $elasticsearchplugin.index(data.value.entry, data.value.entry.slug)
+  const { index } = useIndexer()
+  await index(data.value.entry, data.value.entry.slug)
 }
 
 const page = ref(_get(data.value, 'entry', {}))

--- a/pages/impact/[year]/index.vue
+++ b/pages/impact/[year]/index.vue
@@ -37,7 +37,7 @@ if (!data.value.entry) {
   })
 }
 // console.log("impact report yesr inde page: data value: ", data.value.entry)
-if (data.value.entry.slug && import.meta.server) {
+if (data.value.entry.slug && import.meta.prerender) {
   const { index } = useIndexer()
   await index(data.value.entry, path.replaceAll('/', '--'))
 }

--- a/pages/impact/[year]/index.vue
+++ b/pages/impact/[year]/index.vue
@@ -38,8 +38,8 @@ if (!data.value.entry) {
 }
 // console.log("impact report yesr inde page: data value: ", data.value.entry)
 if (data.value.entry.slug && import.meta.server) {
-  const { $elasticsearchplugin } = useNuxtApp()
-  await $elasticsearchplugin.index(data.value.entry, path.replaceAll('/', '--'))
+  const { index } = useIndexer()
+  await index(data.value.entry, path.replaceAll('/', '--'))
 }
 
 const page = ref(_get(data.value, 'entry', {}))
@@ -163,12 +163,10 @@ const timelineSortedBySubtitle = computed(() => {
       />
     </SectionWrapper>
     <SectionWrapper v-if="page.acknowledgements && page.acknowledgements.length === 1">
-      <h2
-        :class="page.acknowledgements[0].displaySectionTitle === 'true'
-          ? ''
-          : 'visually-hidden'
-        "
-      >
+      <h2 :class="page.acknowledgements[0].displaySectionTitle === 'true'
+        ? ''
+        : 'visually-hidden'
+        ">
         {{ page.acknowledgements[0].titleGeneral }}
       </h2>
       <RichText

--- a/pages/impact/[year]/index.vue
+++ b/pages/impact/[year]/index.vue
@@ -163,10 +163,12 @@ const timelineSortedBySubtitle = computed(() => {
       />
     </SectionWrapper>
     <SectionWrapper v-if="page.acknowledgements && page.acknowledgements.length === 1">
-      <h2 :class="page.acknowledgements[0].displaySectionTitle === 'true'
-        ? ''
-        : 'visually-hidden'
-        ">
+      <h2
+        :class="page.acknowledgements[0].displaySectionTitle === 'true'
+          ? ''
+          : 'visually-hidden'
+        "
+      >
         {{ page.acknowledgements[0].titleGeneral }}
       </h2>
       <RichText

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -26,7 +26,7 @@ if (!data.value.entry) {
   })
 }
 
-if (data.value.entry && import.meta.server) {
+if (data.value.entry && import.meta.prerender) {
   const { index } = useIndexer()
 
   const doc = {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -27,14 +27,15 @@ if (!data.value.entry) {
 }
 
 if (data.value.entry && import.meta.server) {
-  const { $elasticsearchplugin } = useNuxtApp()
+  const { index } = useIndexer()
+
   const doc = {
     title: data.value.entry.title,
     text: data.value.entry.summary,
     searchLinks: data.value.entry.searchLinks,
     uri: '/'
   }
-  await $elasticsearchplugin.index(doc, 'home-page')
+  await index(doc, 'home-page')
 }
 const page = ref(_get(data.value, 'entry', {}))
 watch(data, (newVal, oldVal) => {

--- a/pages/search-site/index.vue
+++ b/pages/search-site/index.vue
@@ -25,7 +25,8 @@ const searchGenericQuery = ref({
   queryFilters: parseFilters(route.query.filters || '')
 })
 const isSearching = ref(true)
-const { $dataApi } = useNuxtApp()
+
+
 // This watcher is called when router push updates the query params
 watch(
   () => route.query,
@@ -50,7 +51,8 @@ async function searchES() {
         ))
     ) {
       // console.log('Search site in router query in asyc data')
-      page.value = await $dataApi.siteSearch(
+      const { siteSearch } = useSearch()
+      page.value = await siteSearch(
         route.query.q || '*',
         route.query.from || from.value,
         parseFilters(route.query.filters || ''),

--- a/pages/search-site/index.vue
+++ b/pages/search-site/index.vue
@@ -26,7 +26,6 @@ const searchGenericQuery = ref({
 })
 const isSearching = ref(true)
 
-
 // This watcher is called when router push updates the query params
 watch(
   () => route.query,

--- a/pages/visit/events-exhibitions/[slug].vue
+++ b/pages/visit/events-exhibitions/[slug].vue
@@ -630,8 +630,10 @@ onMounted(async () => {
       </SectionWrapper>
 
       <SectionWrapper :section-title="parsedAcknowledgementTitle">
-        <RichText :rich-text-content="page.exhibition.acknowledgements[0].acknowledgements
-          " />
+        <RichText
+          :rich-text-content="page.exhibition.acknowledgements[0].acknowledgements
+          "
+        />
       </SectionWrapper>
     </div>
   </main>

--- a/pages/visit/events-exhibitions/[slug].vue
+++ b/pages/visit/events-exhibitions/[slug].vue
@@ -35,7 +35,7 @@ if (!data.value.event && !data.value.eventSeries && !data.value.exhibition) {
 }
 
 if (import.meta.server) {
-  const { $elasticsearchplugin } = useNuxtApp()
+  const { index } = useIndexer()
   if (data.value.eventSeries) data.value.eventSeries.sectionHandle = 'eventSeries'
   if (data.value.event)
     data.value.event.locations = data.value.event.associatedLocations
@@ -45,7 +45,7 @@ if (import.meta.server) {
   if (data.value.exhibition)
     data.value.exhibition.locations =
       data.value.exhibition.associatedLocationsAndPrograms
-  await $elasticsearchplugin?.index(data.value.event || data.value.eventSeries || data.value.exhibition, route.params.slug)
+  await index(data.value.event || data.value.eventSeries || data.value.exhibition, route.params.slug)
 }
 
 // console.log('test:', data.value.event.libcalOnlineSeats, data.value.event.libcalOnlineSeatsTaken)
@@ -630,10 +630,8 @@ onMounted(async () => {
       </SectionWrapper>
 
       <SectionWrapper :section-title="parsedAcknowledgementTitle">
-        <RichText
-          :rich-text-content="page.exhibition.acknowledgements[0].acknowledgements
-          "
-        />
+        <RichText :rich-text-content="page.exhibition.acknowledgements[0].acknowledgements
+          " />
       </SectionWrapper>
     </div>
   </main>

--- a/pages/visit/events-exhibitions/[slug].vue
+++ b/pages/visit/events-exhibitions/[slug].vue
@@ -34,7 +34,7 @@ if (!data.value.event && !data.value.eventSeries && !data.value.exhibition) {
   throw createError({ statusCode: 404, message: 'Page not found', fatal: true })
 }
 
-if (import.meta.server) {
+if (import.meta.prerender) {
   const { index } = useIndexer()
   if (data.value.eventSeries) data.value.eventSeries.sectionHandle = 'eventSeries'
   if (data.value.event)

--- a/pages/visit/events-exhibitions/index.vue
+++ b/pages/visit/events-exhibitions/index.vue
@@ -39,7 +39,7 @@ if (!data.value?.data && !data.value?.single) {
     statusMessage: 'Page Not Found'
   })
 }
-if (data.value.single && import.meta.server) {
+if (data.value.single && import.meta.prerender) {
   const { index } = useIndexer()
   const doc = {
     title: data.value.single.title,

--- a/pages/visit/events-exhibitions/index.vue
+++ b/pages/visit/events-exhibitions/index.vue
@@ -263,14 +263,14 @@ async function searchES() {
     const extrafilters = (past && past.length > 0 && past[0] === 'yes')
       ? []
       : [
-        {
-          range: {
-            endDateWithTime: {
-              gte: 'now',
+          {
+            range: {
+              endDateWithTime: {
+                gte: 'now',
+              },
             },
           },
-        },
-      ]
+        ]
 
     const { keywordSearchWithFilters } = useSearch()
     const results = await keywordSearchWithFilters(
@@ -419,7 +419,7 @@ onMounted(async () => {
       v-show="parsedFeaturedEventsAndExhibits.length > 0 &&
         hits.length == 0 &&
         !noResultsFound
-        "
+      "
       class="section-no-top-margin"
     >
       <BannerFeatured
@@ -454,7 +454,7 @@ onMounted(async () => {
         parsedEvents.length &&
         hits.length == 0 &&
         !noResultsFound
-        "
+      "
       theme="divider"
     >
       <DividerWayFinder color="visit" />
@@ -466,7 +466,7 @@ onMounted(async () => {
         parsedEvents.length > 0 &&
         hits.length == 0 &&
         !noResultsFound
-        "
+      "
       section-title="All Upcoming Events"
     >
       <SectionTeaserList :items="parsedEvents" />
@@ -477,7 +477,7 @@ onMounted(async () => {
         parsedEvents.length > 0 &&
         hits.length == 0 &&
         !noResultsFound
-        "
+      "
       theme="divider"
     >
       <DividerWayFinder color="visit" />
@@ -489,7 +489,7 @@ onMounted(async () => {
         parsedSeriesAndExhibitions.length > 0 &&
         hits.length == 0 &&
         !noResultsFound
-        "
+      "
       section-title="Event Series & Exhibitions"
     >
       <SectionTeaserCard :items="parsedSeriesAndExhibitions" />

--- a/pages/visit/locations/[slug].vue
+++ b/pages/visit/locations/[slug].vue
@@ -40,7 +40,7 @@ if (!data.value.entry) {
     fatal: true
   })
 }
-if (data.value.entry.slug && import.meta.server) {
+if (data.value.entry.slug && import.meta.prerender) {
   const { index } = useIndexer()
   // console.log('Indexing location', data.value.entry.slug)
   await index(data.value.entry, data.value.entry.slug)

--- a/pages/visit/locations/[slug].vue
+++ b/pages/visit/locations/[slug].vue
@@ -41,9 +41,9 @@ if (!data.value.entry) {
   })
 }
 if (data.value.entry.slug && import.meta.server) {
-  const { $elasticsearchplugin } = useNuxtApp()
+  const { index } = useIndexer()
   // console.log('Indexing location', data.value.entry.slug)
-  await $elasticsearchplugin?.index(data.value.entry, data.value.entry.slug)
+  await index(data.value.entry, data.value.entry.slug)
 }
 
 const page = ref(_get(data.value, 'entry', {}))

--- a/pages/visit/locations/index.vue
+++ b/pages/visit/locations/index.vue
@@ -19,7 +19,7 @@ import parseAmenities from '../utils/parseAmenities'
 // GQL
 import LOCATIONS_LIST from '../gql/queries/LocationsList.gql'
 
-const { $graphql, $dataApi } = useNuxtApp()
+const { $graphql } = useNuxtApp()
 
 const route = useRoute()
 
@@ -41,21 +41,21 @@ if (!data.value.entry) {
   })
 }
 if (data.value.entry && import.meta.server) {
-  const { $elasticsearchplugin } = useNuxtApp()
+  const { index } = useIndexer()
   const doc = {
     title: data.value.entry.title,
     text: data.value.entry.text,
     uri: 'visit/locations/'
   }
-  await $elasticsearchplugin.index(doc, 'location-list')
+  await index(doc, 'location-list')
 }
 
 // console.log('In endowment listing page data.value: ', JSON.stringify(data.value))
 // Index data on server only
 if (data?.value?.entry.affiliateLibraries && data.value.entry.affiliateLibraries.length > 0 && import.meta.server) {
-  const { $elasticsearchplugin } = useNuxtApp()
+  const { index } = useIndexer()
   for (const affiliateLibrary of data.value.entry.affiliateLibraries) {
-    await $elasticsearchplugin.index(
+    await index(
       affiliateLibrary,
       affiliateLibrary.slug
     )
@@ -93,7 +93,8 @@ async function searchES() {
   ) {
     // console.log('Search ES HITS query,', route.query.q)
     const queryText = route.query.q || '*'
-    const results = await $dataApi.keywordSearchWithFilters(
+    const { keywordSearchWithFilters } = useSearch()
+    const results = await keywordSearchWithFilters(
       queryText,
       config.locationsList.searchFields,
       'sectionHandle:location OR sectionHandle:affiliateLibrary',
@@ -193,7 +194,8 @@ function showMoreOtherCampusLibrary() {
 }
 
 async function setFilters() {
-  const searchAggsResponse = await $dataApi.getAggregations(
+  const { getAggregations } = useSearch()
+  const searchAggsResponse = await getAggregations(
     config.locationsList.filters,
     'location'
   )
@@ -288,7 +290,7 @@ onMounted(async () => {
         parsedUclaLibraries.length &&
         hits.length == 0 &&
         !noResultsFound
-      "
+        "
       class="section-no-top-margin"
       section-title="UCLA Library Locations"
     >
@@ -310,7 +312,7 @@ onMounted(async () => {
         showOtherCampus &&
         hits.length == 0 &&
         !noResultsFound
-      "
+        "
       section-title="Other Campus Libraries & Archives"
     >
       <SectionLocationList

--- a/pages/visit/locations/index.vue
+++ b/pages/visit/locations/index.vue
@@ -40,7 +40,7 @@ if (!data.value.entry) {
     statusMessage: 'Page Not Found'
   })
 }
-if (data.value.entry && import.meta.server) {
+if (data.value.entry && import.meta.prerender) {
   const { index } = useIndexer()
   const doc = {
     title: data.value.entry.title,
@@ -52,7 +52,7 @@ if (data.value.entry && import.meta.server) {
 
 // console.log('In endowment listing page data.value: ', JSON.stringify(data.value))
 // Index data on server only
-if (data?.value?.entry.affiliateLibraries && data.value.entry.affiliateLibraries.length > 0 && import.meta.server) {
+if (data?.value?.entry.affiliateLibraries && data.value.entry.affiliateLibraries.length > 0 && import.meta.prerender) {
   const { index } = useIndexer()
   for (const affiliateLibrary of data.value.entry.affiliateLibraries) {
     await index(

--- a/pages/visit/locations/index.vue
+++ b/pages/visit/locations/index.vue
@@ -290,7 +290,7 @@ onMounted(async () => {
         parsedUclaLibraries.length &&
         hits.length == 0 &&
         !noResultsFound
-        "
+      "
       class="section-no-top-margin"
       section-title="UCLA Library Locations"
     >
@@ -312,7 +312,7 @@ onMounted(async () => {
         showOtherCampus &&
         hits.length == 0 &&
         !noResultsFound
-        "
+      "
       section-title="Other Campus Libraries & Archives"
     >
       <SectionLocationList


### PR DESCRIPTION
Connected to [APPS-3272](https://jira.library.ucla.edu/browse/APPS-3272)
https://nuxt.com/docs/guide/going-further/features#inlinestyles

This PR has the following updates

- Disable inlineStyles in nuxt-config reduces the generated file size significantly. @farosFreed found it.
- Set crawler to false and only add routes we need to generate pages
- Replace plugins with composables for Elastic search indexing and searching
- Replace import.meta.server to import.meta.prerender

Inline style testing
This is what I found from my testing,

- No more inline styles on the static page
- the component library css is in separate file and loaded once in the header for the page
- the file size reduced significantly which should help with out of memory errors in static builds.
- All styles are still working on static pages

Next steps:  move to using css modules in component library or other ways to do the theme separation and create separate css for each theme and on the nuxt side only add the theme css file relevant for the site. I am still going to look into rollup for further optimization. (edited) 

[APPS-3272]: https://uclalibrary.atlassian.net/browse/APPS-3272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ