### PR TITLE
feat: Search Improvements APPS-2576

### DIFF
--- a/composables/useSearch.ts
+++ b/composables/useSearch.ts
@@ -21,43 +21,6 @@ async function siteSearch(
     config.public.esAlias === ''
   )
     return
-  // console.log('keyword:' + keyword)
-  /* if(keyword && keyword !== "*:*") {
-        keyword = keyword.replace(/([\!\*\+\&\|\(\)\[\]\{\}\^\~\?\:\"])/g, "\\$1")
-    } */
-  console.log('Hello from dataapi',
-    JSON.stringify({
-      from,
-      indices_boost: [{
-        [config.public.esTempIndex]: 1.4
-      },
-      {
-        [config.public.libguidesEsIndex]: 1.3
-      }
-      ],
-      query: {
-        bool: {
-          must: [{
-            query_string: {
-              query: '(' +
-                keyword +
-                ' AND NOT(sectionHandle:event)) OR (' +
-                keyword +
-                ' AND startDateWithTime:[now TO *] AND sectionHandle:event)',
-              fields: [
-                'title^4',
-                'summary^3',
-                'text^3',
-                'richText^2',
-              ],
-              fuzziness: 'auto',
-            },
-          },],
-          filter: [...parseFilterQuerySiteSearch(queryFilters, configMapping)],
-        },
-      },
-    })
-  )
 
   // dataAlias returns:
   // {
@@ -82,7 +45,17 @@ async function siteSearch(
     }
   )
   const dataAlias = await responseAlias.json()
-
+  const searchFields = [
+    'title^6',
+    'nameFirst.autocomplete^3',
+    'nameLast.autocomplete^3',
+    'summary^3',
+    'text^3',
+    'fullText^2',
+    'richText^2',
+    'sectionHandle',
+    'sectionHandleDisplayName'
+  ]
   // use computed values for object keys: indices_boost: [ { [libraryIndex]: 3.0 },{ [libguideIndex]: 1.3 }],
   const libraryIndex = !Object.keys(dataAlias)[0].includes('libguides') ? Object.keys(dataAlias)[0] : Object.keys(dataAlias)[1]
   const libguideIndex = Object.keys(dataAlias)[1].includes('libguides') ? Object.keys(dataAlias)[1] : Object.keys(dataAlias)[0]
@@ -106,10 +79,10 @@ async function siteSearch(
         query: {
           bool: {
             must: [{
-              query_string: {
+              multi_match: {
                 query: keyword,
                 fields: [
-                  'title^4',
+                  'title^6',
                   'nameFirst.autocomplete^3',
                   'nameLast.autocomplete^3',
                   'summary^3',
@@ -119,9 +92,13 @@ async function siteSearch(
                   'sectionHandle',
                   'sectionHandleDisplayName'
                 ],
-                fuzziness: 'auto',
+                fuzziness: 'AUTO',
+                type: 'best_fields',
               },
             },],
+            should: [
+              ...parseShouldQuery(keyword, searchFields),
+            ],
             filter: [...parseFilterQuerySiteSearch(queryFilters, configMapping)],
           },
         },
@@ -268,30 +245,6 @@ async function keywordSearchWithFilters(
   // console.log('filters:' + filters)
   // console.log('sort:' + sort)
 
-  const testquery = JSON.stringify({
-    _source: [...source],
-    query: {
-      bool: {
-        must: [{
-          query_string: {
-            query: keyword,
-            fields: [...searchFields],
-            fuzziness: 'auto',
-          },
-        },
-        ...parseSectionHandle(sectionHandle),
-        ...parseFilterQuery(filters),
-        ...extraFilters,
-        ],
-      },
-    },
-    ...parseSort(sort, orderBy),
-    aggs: {
-      ...parseFieldNames(aggFields),
-    },
-  })
-  // console.log('this is the query: ' + testquery)
-
   // need to know fields to boost on for listing pages when searching like title etc
   const responseAlias = await fetch(
     `${config.public.esURL}/_alias/${config.public.esAlias}`, {
@@ -305,7 +258,7 @@ async function keywordSearchWithFilters(
 
   // use computed values for object keys: indices_boost: [ { [libraryIndex]: 3.0 },{ [libguideIndex]: 1.3 }],
   const libraryIndex = !Object.keys(dataAlias)[0].includes('libguides') ? Object.keys(dataAlias)[0] : Object.keys(dataAlias)[1]
-
+  const sectionHandleFilter = parseSectionHandle(sectionHandle)[0]
   const response = await fetch(
     `${config.public.esURL}/${libraryIndex}/_search`, // replace alias with indexname
     {
@@ -319,17 +272,15 @@ async function keywordSearchWithFilters(
         _source: [...source],
         query: {
           bool: {
-            must: [{
-              query_string: {
-                query: keyword,
-                fields: [...searchFields],
-                fuzziness: 'auto',
-              },
-            },
-            ...parseSectionHandle(sectionHandle),
-            ...parseFilterQuery(filters),
-            ...extraFilters,
+            must: [
+              ...parseMultiMatchQueryOrQueryString(keyword, searchFields),
+              ...parseFilterQuery(filters),
+              ...extraFilters,
             ],
+            should: [
+              ...parseShouldQuery(keyword, searchFields),
+            ],
+            ...(sectionHandleFilter && { filter: sectionHandleFilter }),
           },
         },
         ...parseSort(sort, orderBy),
@@ -343,28 +294,110 @@ async function keywordSearchWithFilters(
   return data
 }
 
+interface ParseQueryType {
+  sort: {
+    [key: string]: {
+      order: string
+    }
+  }[]
+}
+
 function parseSort(sortField, orderBy = 'asc') {
   if (!sortField || sortField === '') return {}
-  const parseQuery = {}
-  parseQuery.sort = []
+  const parseQuery: ParseQueryType = { sort: [] }
+  /**
+     * { "_score": "desc" },
+     */
   parseQuery.sort[0] = {}
-  parseQuery.sort[0][sortField] = {
+  parseQuery.sort[0]._score = {
+    order: 'desc'
+  }
+  parseQuery.sort[1] = {}
+  parseQuery.sort[1][sortField] = {
     order: orderBy
   }
 
   return parseQuery
 }
 
-function parseSectionHandle(sectionHandle) {
-  // console.log(sectionHandle)
-  if (sectionHandle && sectionHandle === '') return []
-  // console.log("where is the execution")
+function parseSectionHandle(sectionHandleValues) {
+  if (sectionHandleValues && sectionHandleValues.length === 0) return []
+
+  if (sectionHandleValues.length === 3) {
+    if (sectionHandleValues.includes('serviceOrResource') && sectionHandleValues.includes('workshopSeries') && sectionHandleValues.includes('helpTopic')) {
+      return [parseExternalResourceFilterQuery(sectionHandleValues)]
+    }
+  }
   const boolQuery = []
   const sectionHandleTermQueryObj = {}
-  sectionHandleTermQueryObj.query_string = {}
-  sectionHandleTermQueryObj.query_string.query = sectionHandle
+  if (sectionHandleValues.length === 1) sectionHandleTermQueryObj.term = { 'sectionHandle.keyword': sectionHandleValues[0] }
+  else sectionHandleTermQueryObj.terms = { 'sectionHandle.keyword': sectionHandleValues }
   boolQuery.push(sectionHandleTermQueryObj)
-  // console.log("query:" + boolQuery)
+  // console.log('query:' + JSON.stringify(boolQuery))
+  return boolQuery
+}
+
+function parseExternalResourceFilterQuery(filters) {
+  /**
+   * "bool": {
+          "should": [
+            {
+              "terms": {
+                "sectionHandle.keyword": [
+                  "serviceOrResource",
+                  "workshopSeries",
+                  "helpTopic"
+                ]
+              }
+            },
+            {
+              "bool": {
+                "must": [
+                  {
+                    "term": {
+                      "sectionHandle.keyword": "externalResource"
+                    }
+                  },
+                  {
+                    "term": {
+                      "displayEntry.keyword": "yes"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "minimum_should_match": 1
+        }
+   */
+  if (filters && filters.length === 0) return []
+  const boolQuery = { bool: { should: [], minimum_should_match: 1 } }
+  const shouldQuery = []
+  const termsQuery = {
+    terms: {
+      'sectionHandle.keyword': filters,
+    },
+  }
+  const mustQuery = {
+    bool: {
+      must: [
+        {
+          term: {
+            'sectionHandle.keyword': 'externalResource'
+          },
+        },
+        {
+          term: {
+            'displayEntry.keyword': 'yes'
+          },
+        },
+      ],
+    },
+  }
+  shouldQuery.push(termsQuery)
+  shouldQuery.push(mustQuery)
+  boolQuery.bool.should = shouldQuery
+  // console.log("bool query:" + JSON.stringify(boolQuery))
   return boolQuery
 }
 
@@ -414,4 +447,76 @@ function parseFieldNames(fields) {
   }
   // console.log("aggsFields:" + JSON.stringify(aggsFields))
   return aggsFields
+}
+function parseMultiMatchQueryOrQueryString(keyword: string, searchFields: any) {
+  /*
+  {
+              multi_match: {
+                query: keyword,
+                fields: [...searchFields],
+                type: "best_fields"
+              },
+            },
+  */
+  console.log('In parseMultiMatchQuery')
+  console.log(keyword, searchFields)
+  if (keyword.includes('searchType:accessCollection')) {
+    return [{
+      query_string: {
+        query: keyword,
+        fields: searchFields
+      }
+    }]
+  }
+
+  if (keyword === '*') return [{ match_all: {} }]
+  else
+    return [
+      {
+        multi_match: {
+          query: keyword,
+          fields: [...searchFields],
+          fuzziness: 'AUTO',
+          type: 'best_fields',
+        },
+      },
+    ]
+}
+function parseShouldQuery(keyword: string, searchFields: any) {
+  /*
+  {
+                multi_match: {
+                  query: keyword,
+                  fields: [...searchFields],
+                  fuzziness: "AUTO"
+                }
+              },
+              {
+                match_phrase: {
+                  title: {
+                    query: keyword,
+                    boost: 3
+                  }
+                }
+              }
+  */
+  if (keyword === '*') return [{ match_all: {} }]
+  else
+    return [
+      {
+        multi_match: {
+          query: keyword,
+          fields: [...searchFields],
+          fuzziness: 'AUTO'
+        }
+      },
+      {
+        match_phrase: {
+          title: {
+            query: keyword,
+            boost: 3
+          }
+        }
+      },
+    ]
 }

--- a/composables/useSearch.ts
+++ b/composables/useSearch.ts
@@ -107,11 +107,7 @@ async function siteSearch(
           bool: {
             must: [{
               query_string: {
-                query: '(' +
-                keyword +
-                ' AND NOT(sectionHandle:event)) OR (' +
-                keyword +
-                ' AND startDateWithTime:[now TO *] AND sectionHandle:event)',
+                query: keyword,
                 fields: [
                   'title^4',
                   'nameFirst.autocomplete^3',

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "nuxt-graphql-request": "^7.0.5",
     "sass": "^1.66.1",
     "ucla-library-design-tokens": "^5.27.0",
-    "@ucla-library-monorepo/ucla-library-website-components": "^1.8.0"
+    "@ucla-library-monorepo/ucla-library-website-components": "^1.9.0"
   },
   "engines": {
     "pnpm": "^9.12.1"

--- a/pages/about/news/index.vue
+++ b/pages/about/news/index.vue
@@ -201,7 +201,7 @@ async function searchES() {
     const results = await keywordSearchWithFilters(
       queryText,
       config.newsIndex.searchFields,
-      'sectionHandle:article',
+      ['article'],
       parseFilters(route.query.filters || ''),
       config.newsIndex.sortField,
       config.newsIndex.orderBy,

--- a/pages/about/programs/index.vue
+++ b/pages/about/programs/index.vue
@@ -87,7 +87,7 @@ async function searchES() {
     const results = await keywordSearchWithFilters(
       queryText as string,
       config.programsList.searchFields,
-      'sectionHandle:program',
+      ['program'],
       parseFilters(route.query.filters || ''),
       config.programsList.sortField,
       config.programsList.orderBy,

--- a/pages/about/staff/index.vue
+++ b/pages/about/staff/index.vue
@@ -137,7 +137,7 @@ async function searchES() {
   const results = await keywordSearchWithFilters(
     queryText,
     config.staff.searchFields,
-    'sectionHandle:staffMember',
+    ['staffMember'],
     filters,
     config.staff.sortField,
     config.staff.orderBy,

--- a/pages/collections/access/index.vue
+++ b/pages/collections/access/index.vue
@@ -86,12 +86,13 @@ const searchGenericQuery = ref({
 async function searchES() {
   if (route?.query && route?.query.q && route?.query.q !== '') {
     // console.log('searchES', route.query.q)
-    const queryText = route.query.q || '*'
+    let queryText = route.query.q || '*'
+    queryText = queryText + ' AND searchType:accessCollection'
     const { keywordSearchWithFilters } = useSearch()
     const results = await keywordSearchWithFilters(
       queryText,
       config.accessCollections.searchFields,
-      'searchType:accessCollection',
+      [],
       {},
       config.accessCollections.sortField,
       config.accessCollections.orderBy,

--- a/pages/collections/explore/index.vue
+++ b/pages/collections/explore/index.vue
@@ -140,7 +140,7 @@ async function searchES() {
     const results = await keywordSearchWithFilters(
       queryText,
       config.exploreCollection.searchFields,
-      'sectionHandle:collection',
+      ['collection'],
       parseFilters(route.query.filters || ''),
       config.exploreCollection.sortField,
       config.exploreCollection.orderBy,

--- a/pages/give/endowments/index.vue
+++ b/pages/give/endowments/index.vue
@@ -154,7 +154,7 @@ async function searchES() {
     const results = await keywordSearchWithFilters(
       queryText,
       config.endowmentsList.searchFields,
-      'sectionHandle:endowment',
+      ['endowment'],
       parseFilters(route.query.filters || ''),
       config.endowmentsList.sortField,
       config.endowmentsList.orderBy,

--- a/pages/help/services-resources/index.vue
+++ b/pages/help/services-resources/index.vue
@@ -119,7 +119,9 @@ async function searchES() {
     const results = await keywordSearchWithFilters(
       queryText,
       config.serviceOrResources.searchFields,
-      '(sectionHandle:serviceOrResource OR sectionHandle:workshopSeries OR sectionHandle:helpTopic) OR (sectionHandle:externalResource AND displayEntry:yes)',
+      ['serviceOrResource',
+        'workshopSeries',
+        'helpTopic'],
       parseFilters(route.query.filters || ''),
       config.serviceOrResources.sortField,
       config.serviceOrResources.orderBy,

--- a/pages/search-site/index.vue
+++ b/pages/search-site/index.vue
@@ -256,6 +256,17 @@ const parsedTime = (props) => {
   return formatTimes(props.startDate, props.endDate)
 }
 
+useHead({
+  title: 'Search Site',
+  meta: [
+    {
+      hid: 'description',
+      name: 'description',
+      content: 'The UCLA Library creates a vibrant nexus of ideas, collections, expertise, and spaces in which users illuminate solutions for local and global challenges. We constantly evolve to advance UCLA’s research, education, and public service mission by empowering and inspiring communities of scholars and learners to discover, access, create, share, and preserve knowledge.',
+    },
+  ],
+})
+
 </script>
 <template lang="html">
   <main

--- a/pages/visit/events-exhibitions/index.vue
+++ b/pages/visit/events-exhibitions/index.vue
@@ -276,9 +276,9 @@ async function searchES() {
     const results = await keywordSearchWithFilters(
       queryText,
       config.eventsExhibitionsList.searchFields,
-      'sectionHandle:event OR sectionHandle:exhibition OR sectionHandle:eventSeries',
+      ['event', 'exhibition', 'eventSeries'],
       filters, // following this line in nuxt 2 https://github.com/UCLALibrary/library-website-nuxt/blob/main/pages/visit/events-exhibitions/index.vue#L245C19-L245C24
-      config.eventsExhibitionsList.sortField,
+      queryText === '*' ? config.eventsExhibitionsList.sortField : '',
       config.eventsExhibitionsList.orderBy,
       config.eventsExhibitionsList.resultFields,
       config.eventsExhibitionsList.filters,

--- a/pages/visit/locations/index.vue
+++ b/pages/visit/locations/index.vue
@@ -97,7 +97,7 @@ async function searchES() {
     const results = await keywordSearchWithFilters(
       queryText,
       config.locationsList.searchFields,
-      'sectionHandle:location OR sectionHandle:affiliateLibrary',
+      ['location', 'affiliateLibrary'],
       parseFilters(route.query.filters || ''),
       config.locationsList.sortField,
       config.locationsList.orderBy,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: ^18.17.3
         version: 18.19.76
       '@ucla-library-monorepo/ucla-library-website-components':
-        specifier: ^1.8.0
-        version: 1.8.0(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3))(vuetify@3.7.13(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3)))
+        specifier: ^1.9.0
+        version: 1.9.0(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3))(vuetify@3.7.13(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3)))
       '@zadigetvoltaire/nuxt-gtm':
         specifier: ^0.0.13
         version: 0.0.13(magicast@0.3.5)(nuxt@3.15.4(@netlify/blobs@8.1.0)(@parcel/watcher@2.5.1)(@types/node@18.19.76)(db0@0.2.4)(eslint@8.57.1)(ioredis@5.5.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.34.8)(sass@1.85.0)(terser@5.39.0)(typescript@5.7.3)(vite@6.1.1(@types/node@18.19.76)(jiti@2.4.2)(sass@1.85.0)(terser@5.39.0)(yaml@2.7.0))(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))
@@ -1734,8 +1734,8 @@ packages:
     resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
-  '@ucla-library-monorepo/ucla-library-website-components@1.8.0':
-    resolution: {integrity: sha512-kbGPfHvHgtRXwEvYy4U65djkVOfX3ebVCjdKNHPbR3mW+MALVyRzeY9KTibZ2Y3iUdZ/nChFGY1XCaXRpL3hyQ==}
+  '@ucla-library-monorepo/ucla-library-website-components@1.9.0':
+    resolution: {integrity: sha512-zroFvJJCfnjqTKhNB0/BscLd8rquNZHSAhWXsSWiKFfLgJsMyLnKXonRHLzh+Bs1x3N/4vPF7kJ7DGn5PMnEvw==}
     engines: {pnpm: ^9.12.1}
     peerDependencies:
       vue: ^3.5.12
@@ -9594,7 +9594,7 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       eslint-visitor-keys: 3.4.3
 
-  '@ucla-library-monorepo/ucla-library-website-components@1.8.0(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3))(vuetify@3.7.13(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3)))':
+  '@ucla-library-monorepo/ucla-library-website-components@1.9.0(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3))(vuetify@3.7.13(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3)))':
     dependencies:
       '@vuepic/vue-datepicker': 8.8.1(vue@3.5.13(typescript@5.7.3))
       '@vueuse/components': 11.3.0(vue@3.5.13(typescript@5.7.3))

--- a/utils/formatDates.js
+++ b/utils/formatDates.js
@@ -1,0 +1,52 @@
+import format from 'date-fns/format'
+
+/**
+ * Take two date strings, and return them in human readable date formats for Events
+ *
+ * @param {string} startDate
+ * @param {string} endDate
+ * @param {string} dateFormat - 'long', 'short', or 'shortWithYear'
+ * @returns {string}
+ */
+
+function formatDates(startDate = '', endDate = '', dateFormat = 'long') {
+  const start = format(new Date(startDate), 'MMMM d, Y')
+  // console.log(start)
+  const end = format(new Date(endDate), 'MMMM d, Y')
+
+  // "February 11 2020 – May 31 2021"
+  let output = `${start} - ${end}`
+
+  if (start === end) {
+    // Thursday, January 28
+    output = format(new Date(startDate), 'MMMM d, Y')
+  }
+
+  if (!endDate) {
+    // February 11 2020
+    output = start
+  }
+
+  if (dateFormat === 'short' || dateFormat === 'shortWithYear') {
+    // "Feb 11 2020"
+    const day = output.slice(0, 3)
+    const dateYear = output.split(' ').slice(1).join(' ')
+    if (endDate && endDate !== startDate) {
+      // Feb 11 – May 31
+      const shortFormatStartDate = format(new Date(startDate), 'MMM d')
+      const shortFormatEndDate = format(new Date(endDate), 'MMM d')
+      // if 'shortWithYear' is selected, add the year to the end date
+      // Feb 11 – May 31 2020
+      if (dateFormat === 'shortWithYear') {
+        const shortFormatEndDateYear = format(new Date(endDate), 'MMM d, Y')
+        return `${shortFormatStartDate} - ${shortFormatEndDateYear}`
+      }
+      return `${shortFormatStartDate} - ${shortFormatEndDate}`
+    }
+    return `${day} ${dateYear}`
+  }
+
+  return output
+}
+
+export default formatDates

--- a/utils/formatTimes.js
+++ b/utils/formatTimes.js
@@ -1,0 +1,31 @@
+import format from 'date-fns/format'
+
+/**
+ * Take two date strings, and return them in human readable time for Events
+ *
+ * @param {string} startDate
+ * @param {string} endDate
+ * @returns {string}
+ */
+
+function formatTimes(startDate = '', endDate = '') {
+  const start = format(new Date(startDate), 'h:mm aaa')
+  const end = format(new Date(endDate), 'h:mm aaa')
+
+  // "9:00 am – 1:00 pm"
+  let output = `${start} - ${end}`
+
+  if (start === end) {
+    // "9:00 am"
+    output = format(new Date(startDate), 'h:mm aaa')
+  }
+
+  if (!endDate) {
+    // 9:00 am
+    output = start
+  }
+
+  return output
+}
+
+export default formatTimes

--- a/utils/searchConfig.js
+++ b/utils/searchConfig.js
@@ -23,7 +23,7 @@ const config = {
       },
       {
         key: 'Events & Exhibitions',
-        terms: ['event', 'workshopOrEventSeries', 'exhibition'],
+        terms: ['event', 'workshopSeries', 'eventSeries', 'exhibition'],
       },
       {
         key: 'Featured Collection',

--- a/utils/searchConfig.js
+++ b/utils/searchConfig.js
@@ -74,7 +74,7 @@ const config = {
       'sectionHandle',
       'illustrationsResourcesAndServices',
       'uri',
-      'type',
+      'type'
     ],
     filters: [
       {
@@ -186,7 +186,7 @@ const config = {
   },
   newsIndex: {
     searchFields: [
-      'title^3',
+      'title^6',
       'text^3',
       'contributors*^2'
     ],
@@ -269,7 +269,7 @@ const config = {
     orderBy: 'asc',
   },
   programsList: {
-    searchFields: ['title^3', 'text^3'],
+    searchFields: ['title^6', 'text^3'],
     filters: [
       {
         label: 'Type',
@@ -283,8 +283,8 @@ const config = {
   },
   eventsExhibitionsList: {
     searchFields: [
-      'title^3',
-      'eventDescription^3',
+      'title^6',
+      'eventDescription^2',
       'summary^3',
       'text^3',
       'sectionHandle',


### PR DESCRIPTION
# 🔍 Search Improvements

**JIRA:** [APPS-2576](https://jira.library.ucla.edu/browse/APPS-2576) and [APPS-3252](https://uclalibrary.atlassian.net/browse/APPS-3252)

This PR improves the accuracy, relevance, and flexibility of our Elasticsearch keyword search.

---

## ✅ Summary of Changes

- Enabled typo tolerance using `fuzziness: AUTO` (e.g., `telivision` → `television`)
- Switched from `query_string` fuzziness to a layered `bool` query:
  - `must`: exact match (`multi_match`)
  - `should`: fuzzy match + `match_phrase` for boosting
  - `filter`: scoped filtering (e.g., `sectionHandle`, `displayEntry`)
- Fixed issue where sorting by `title.keyword` caused `_score` to be `null`
- Now sorting by relevance (`_score`) first, then alphabetically

---

## 🧠 Why These Changes Matter

- Avoids noisy fuzzy results like `"cheese"` when searching for `"chinese"`
- Ensures typo tolerance doesn’t reduce ranking of exact matches
- Fixes `_score` being ignored when sorting, so top results are now actually relevant
- Supports complex logic (e.g., `sectionHandle = externalResource AND displayEntry = yes` OR predefined section handles)

---

## 🧪 Examples

### Fuzzy Matching

```
Search: cultural
Matches: cultural, culturla, culutral, cultural

### Sorting Fix
```json
"sort": [
  { "_score": "desc" },
  { "title.keyword": "asc" }
]
```
#### Lucene-style Field Query Support

```
{
  "query_string": {
    "query": "avalon AND searchType:accessCollection",
    "fields": ["title^6", "summary^6", "text^6", "searchType"]
  }
}

```

📈 Result
✅ Better relevance and ranking
✅ Smarter typo-tolerance

**Other Fixes**

1. Prev Next links with filters broken on site search
2. undefined page tile on site search

**old**
https://www.library.ucla.edu/search-site?q=My+life+in+the+sunshine
**new**
https://uclalibrary-stage.netlify.app/search-site/?q=My+life+in+the+sunshine&filters=

**old**
https://www.library.ucla.edu/search-site/?q=tea+coffee&filters=
**new**
https://uclalibrary-stage.netlify.app/search-site/?q=tea+coffee&filters=

**old**
https://www.library.ucla.edu/search-site/?q=carpentaries
**new**
https://uclalibrary-stage.netlify.app/search-site/?q=carpentaries&filters=

**old**
https://www.library.ucla.edu/search-site/?q=chineese&filters=
**new**
https://uclalibrary-stage.netlify.app/search-site/?q=chineese&filters=


**old**
https://www.library.ucla.edu/visit/events-exhibitions/?q=My+life+in+the+sunshine&filters=past:(yes)
**new**
https://uclalibrary-stage.netlify.app/visit/events-exhibitions?q=My+life+in+the+sunshine&filters=past:(yes)

**old**
https://www.library.ucla.edu/visit/events-exhibitions?q=family+flicks&filters=past:(yes)
**new**
https://uclalibrary-stage.netlify.app/visit/events-exhibitions/?q=family+flicks&filters=past:(yes)

**old**
https://www.library.ucla.edu/visit/events-exhibitions/?q=human&filters=past:(yes)
**new**
https://uclalibrary-stage.netlify.app/visit/events-exhibitions/?q=human&filters=past:(yes)

[APPS-2576]: https://uclalibrary.atlassian.net/browse/APPS-2576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[APPS-3252]: https://uclalibrary.atlassian.net/browse/APPS-3252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ