### PR TITLE
feat: LADI-5132 new sass packages, update nuxt-config to allow imports for now

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -100,11 +100,17 @@ export default defineNuxtConfig({
     css: {
       preprocessorOptions: {
         scss: {
-          additionalData: `
+          api: 'modern-compiler',
+          // FUNCTION CAN BE REMOVED AFTER REFACTOR TO REMOVE @IMPORTS
+          // app-global.scss starts with @forward; Sass requires @forward before any @import.
+          // A string additionalData would prepend @imports and break that file.
+          additionalData: (source: string, filename: string) => {
+            if (filename.includes('app-global.scss')) return source
+            return `
                         @import "ucla-library-design-tokens/scss/fonts.scss";
                         @import "ucla-library-design-tokens/scss/app.scss";
-                    `,
-          api: 'modern-compiler', // or 'modern'
+                    ${source}`
+          },
         },
       },
     }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "netlify-cli": "^17.36.0",
     "nuxt-graphql-request": "^7.0.5",
     "sass": "^1.66.1",
-    "ucla-library-design-tokens": "^5.56.0",
+    "ucla-library-design-tokens": "^6.0.1",
     "@ucla-library-monorepo/ucla-library-website-components": "^1.72.1"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,8 +76,8 @@ importers:
         specifier: ^1.66.1
         version: 1.85.0
       ucla-library-design-tokens:
-        specifier: ^5.56.0
-        version: 5.56.0
+        specifier: ^6.0.1
+        version: 6.0.1
 
 packages:
 
@@ -7379,8 +7379,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ucla-library-design-tokens@5.56.0:
-    resolution: {integrity: sha512-J7047TOVuuI56n3Grrw0Ja/4zNl7BmYhu0HRGjbVeH2ryeNfsVpImsVuYYDCIktuF7bKbSChu24peFIH/ijgbg==}
+  ucla-library-design-tokens@6.0.1:
+    resolution: {integrity: sha512-ilqZrjf3P7y6ByVqbUKeI5QvBXBOL5BTZVj+EAeCDddQa5FzwgdxlM2KCvzrm1na+62CrfanxStrOkVliAXAxw==}
 
   ufo@1.5.4:
     resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
@@ -16952,7 +16952,7 @@ snapshots:
 
   typescript@5.7.3: {}
 
-  ucla-library-design-tokens@5.56.0: {}
+  ucla-library-design-tokens@6.0.1: {}
 
   ufo@1.5.4: {}
 


### PR DESCRIPTION
Connected to [LADI-5132](https://jira.library.ucla.edu/browse/LADI-5132)

**Notes:**

This PR is meant as a patch for the library site so that it can use the newly refactored components / design-tokens repo. It can be tested and merged once these PR's have been merged, released, and package.json has been updated

new design-tokens: https://github.com/UCLALibrary/design-tokens/pull/171 ⛙ (merged)
new component library: https://github.com/UCLALibrary/ucla-library-website-components/pull/930

**Time Report:**

This took me 3ish hours to build this.

**Checklist:**

-   [X] I added github label for semantic versioning
-   [X] I double checked it looks like the designs
-   [X] I completed any required mobile breakpoint styling
-   [X] I completed any required hover state styling
-   [X] I included a working spec file
-   [X] I added notes above about how long it took to build this component
-   [ ] UX has reviewed this PR
-   [ ] I assigned this PR to someone to review


[LADI-5132]: https://uclalibrary.atlassian.net/browse/LADI-5132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ