### PR TITLE
feat: LADI-5240 Add External Article Entry Type

### DIFF
--- a/app/pages/about/news/index.vue
+++ b/app/pages/about/news/index.vue
@@ -212,7 +212,7 @@ async function searchES() {
     const results = await keywordSearchWithFilters(
       queryText,
       config.newsIndex.searchFields,
-      ['article'],
+      ['article', 'externalArticle'],
       parseFilters(route.query.filters || ''),
       config.newsIndex.sortField,
       config.newsIndex.orderBy,
@@ -257,8 +257,12 @@ function parseHits(hits = []) {
     // //console.log(obj["_source"]["image"])
     return {
       ...obj._source,
-      description: obj._source.text,
-      date: obj._source.postDate,
+      description: obj._source.text === null || obj._source.text === undefined
+        ? obj._source.description
+        : obj._source.text,
+      date: obj._source.postDate === null || obj._source.postDate === undefined
+        ? obj._source.date
+        : obj._source.postDate,
       articleCategories: obj._source.category,
       to: obj._source.externalResourceUrl != null
         ? _get(obj._source, 'externalResourceUrl', '')
@@ -267,7 +271,7 @@ function parseHits(hits = []) {
       staffName: obj._source.fullName,
       // category: _get(obj["_source"], "category[0].title", null),
       category: parseArticleCategory(
-        obj._source.category
+        obj._source.category || obj._source.articleCategories
       ),
     }
   })

--- a/app/pages/about/news/index.vue
+++ b/app/pages/about/news/index.vue
@@ -429,6 +429,9 @@ const { hasCTA } = useAskALibrarianCTA()
       <SectionStaffArticleList :items="parseHitsResults" />
     </SectionWrapper>
 
+<h3>NEWS</br><pre>{{news}}</pre></h3>
+<h3>HITS</br><pre>{{hits}}</pre></h3>
+
     <!-- NO RESULTS -->
     <SectionWrapper
       v-show="noResultsFound"

--- a/app/pages/about/news/index.vue
+++ b/app/pages/about/news/index.vue
@@ -429,9 +429,6 @@ const { hasCTA } = useAskALibrarianCTA()
       <SectionStaffArticleList :items="parseHitsResults" />
     </SectionWrapper>
 
-<h3>NEWS</br><pre>{{news}}</pre></h3>
-<h3>HITS</br><pre>{{hits}}</pre></h3>
-
     <!-- NO RESULTS -->
     <SectionWrapper
       v-show="noResultsFound"

--- a/app/pages/search-site/index.vue
+++ b/app/pages/search-site/index.vue
@@ -327,7 +327,7 @@ useHead({
           <SearchResult
             :title="result.title"
             :category="parseCategory(result.sectionHandle)"
-            :summary="result.summary || result.text"
+            :summary="result.summary || result.text || result.description"
             :to="result.to"
             class="search-result-item"
           >

--- a/app/utils/flattenTimeLineStructure.js
+++ b/app/utils/flattenTimeLineStructure.js
@@ -15,7 +15,13 @@ function flattenTimeLineStructure(timeLineData = []) {
       obj.headlineText = subitem.contentLink && subitem.contentLink[0] ? subitem.contentLink[0].headlineText : subitem.headlineText
       obj.snippet = subitem.contentLink && subitem.contentLink[0] ? subitem.contentLink[0].snippet : subitem.snippet
       obj.featured = subitem.featured === 'true'
-      obj.to = subitem.contentLink && subitem.contentLink[0] ? `/${subitem.contentLink[0].to}` : subitem.to
+      obj.to = subitem.contentLink && subitem.contentLink[0]
+        ? (
+            subitem.contentLink[0].contentType === 'externalArticle'
+              ? subitem.contentLink[0].to
+              : `/${subitem.contentLink[0].to}`
+          )
+        : subitem.to
       // console.log("subitem content link:",subitem)
       obj.image = subitem.contentLink && subitem.contentLink[0] && subitem.contentLink[0].heroImage && subitem.contentLink[0].heroImage.length > 0 && subitem.contentLink[0].heroImage[0].image ? subitem.contentLink[0].heroImage[0].image[0] : subitem.image ? subitem.image[0] : {}
       flattenedValues.push(obj)

--- a/app/utils/searchConfig.js
+++ b/app/utils/searchConfig.js
@@ -35,7 +35,7 @@ const config = {
       },
       {
         key: 'News',
-        terms: ['article'],
+        terms: ['article', 'externalArticle'],
       },
       {
         key: 'Policies',
@@ -209,11 +209,14 @@ const config = {
     resultFields: [
       'title',
       'text',
+      'description',
       'articleType',
       'uri',
       'heroImage',
       'postDate',
+      'date',
       'category',
+      'articleCategories',
       'contributors',
       'externalResourceUrl',
     ],

--- a/gql/fragments/BlockBannerFeaturedFragment.gql
+++ b/gql/fragments/BlockBannerFeaturedFragment.gql
@@ -9,6 +9,7 @@ fragment BlockBannerFeaturedFragment on ElementInterface {
                 contentType: sectionHandle
                 title
                 to: uri
+                externalResourceUrl
                 summary
                 physicalDigital
                 workshopOrEventSeriesType

--- a/gql/fragments/BlockCardWithImageFragment.gql
+++ b/gql/fragments/BlockCardWithImageFragment.gql
@@ -13,6 +13,7 @@ fragment BlockCardWithImageFragment on ElementInterface {
                 # category: typeHandle
                 contentType: sectionHandle
                 to: uri
+                externalResourceUrl
                 title
                 text: summary
                 eventDescription

--- a/gql/fragments/BlockGridGalleryCardsFragment.gql
+++ b/gql/fragments/BlockGridGalleryCardsFragment.gql
@@ -11,6 +11,7 @@ fragment BlockGridGalleryCardsFragment on ElementInterface {
                     headlineText: title
                     snippet: summary
                     to: uri
+                    externalResourceUrl
                     heroImage {
                         ... on heroImage_heroImage_BlockType {
                             image {
@@ -45,6 +46,7 @@ fragment BlockGridGalleryCardsFragment on ElementInterface {
                     headlineText: title
                     snippet: summary
                     to: uri
+                    externalResourceUrl
                     heroImage {
                         ... on heroImage_heroImage_BlockType {
                             image {

--- a/gql/fragments/BlockHighlightFragment.gql
+++ b/gql/fragments/BlockHighlightFragment.gql
@@ -12,6 +12,7 @@ fragment BlockHighlightFragment on ElementInterface {
                 # category: typeHandle
                 contentType: sectionHandle
                 to: uri
+                externalResourceUrl
                 title
                 text: summary
                 eventDescription

--- a/gql/queries/ArticleList.gql
+++ b/gql/queries/ArticleList.gql
@@ -2,33 +2,31 @@
 
 query ArticleList {
   entries(
-    section: "article"
+    section: ["article", "externalArticle"]
     orderBy: "postDate DESC"
   ) {
-    ... on article_article_Entry {
-      title
-      to: uri
-      slug
-      sectionHandle
-      externalResourceUrl
-      heroImage {
-        ... on heroImage_heroImage_BlockType {
-          id
-          image {
-            ...Image
-          }
+    title
+    to: uri
+    slug
+    sectionHandle
+    externalResourceUrl
+    heroImage {
+      ... on heroImage_heroImage_BlockType {
+        id
+        image {
+          ...Image
         }
       }
-      description: summary
-      authors: staffMember {
-        title
-      }
-      date: postDate
-      articleCategories {
-        id
-        title
-        uri
-      }
+    }
+    description: summary
+    authors: staffMember {
+      title
+    }
+    date: postDate
+    articleCategories {
+      id
+      title
+      uri
     }
   }
 

--- a/gql/queries/CollectionsList.gql
+++ b/gql/queries/CollectionsList.gql
@@ -50,7 +50,7 @@ query CollectionsList {
         }
     }
     entries(
-        section: "article"
+        section: ["article", "externalArticle"]
         relatedToCategories: [{ title: "collections" }]
         orderBy: "postDate DESC"
         limit: 3

--- a/gql/queries/ImpactReport.gql
+++ b/gql/queries/ImpactReport.gql
@@ -45,6 +45,7 @@ query ImpactReport($path: [String!]) {
                 headlineText: title
                 snippet: summary
                 to: uri
+                externalResourceUrl
                 heroImage {
                   ... on heroImage_heroImage_BlockType {
                     image {

--- a/gql/queries/LocationDetail.gql
+++ b/gql/queries/LocationDetail.gql
@@ -73,39 +73,37 @@ query LocationDetail($slug: [String!]) {
         }
     }
     associatedArticles: entries(
-        section: "article"
+        section: ["article", "externalArticle"]
         relatedToEntries: { section: "location", slug: $slug }
         orderBy: "dateUpdated desc"
         limit: 3
     ) {
-        ... on article_article_Entry {
+        id
+        title
+        associatedLocations {
             id
             title
-            associatedLocations {
-                id
-                title
-            }
-            to: slug
-            heroImage {
-                ... on heroImage_heroImage_BlockType {
-                    id
-                    image {
-                        ...Image
-                    }
-                    altText
-                }
-            }
-
-            authors: staffMember {
-                id
-                slug
-                title
-            }
-            description: summary
-            category: typeHandle
-            startDate: dateUpdated
-            endDate: dateUpdated
         }
+        to: slug
+        heroImage {
+            ... on heroImage_heroImage_BlockType {
+                id
+                image {
+                    ...Image
+                }
+                altText
+            }
+        }
+
+        authors: staffMember {
+            id
+            slug
+            title
+        }
+        description: summary
+        category: typeHandle
+        startDate: dateUpdated
+        endDate: dateUpdated
     }
     associatedEndowments: entries(
         section: "endowments"

--- a/gql/queries/LocationDetail.gql
+++ b/gql/queries/LocationDetail.gql
@@ -85,6 +85,7 @@ query LocationDetail($slug: [String!]) {
             title
         }
         to: slug
+        externalResourceUrl
         heroImage {
             ... on heroImage_heroImage_BlockType {
                 id

--- a/gql/queries/ProgramDetail.gql
+++ b/gql/queries/ProgramDetail.gql
@@ -37,33 +37,31 @@ query ProgramDetail($slug: [String!]) {
         ...AllFpb
     }
     associatedArticles: entries(
-        section: "article"
+        section: ["article", "externalArticle"]
         relatedToEntries: { section: "program", slug: $slug }
         orderBy: "dateUpdated desc"
         limit: 3
     ) {
-        ... on article_article_Entry {
+        id
+        title
+        associatedArticles {
             id
             title
-            associatedArticles {
-                id
-                title
-            }
-            to: uri
-            externalResourceUrl
-            heroImage {
-                ... on heroImage_heroImage_BlockType {
-                    id
-                    image {
-                        ...Image
-                    }
-                    altText
-                }
-            }
-            description: summary
-            category: typeHandle
-            startDate: dateCreated
-            endDate: dateCreated
         }
+        to: uri
+        externalResourceUrl
+        heroImage {
+            ... on heroImage_heroImage_BlockType {
+                id
+                image {
+                    ...Image
+                }
+                altText
+            }
+        }
+        description: summary
+        category: typeHandle
+        startDate: dateCreated
+        endDate: dateCreated
     }
 }

--- a/gql/queries/StaffDetail.gql
+++ b/gql/queries/StaffDetail.gql
@@ -50,33 +50,31 @@ query StaffDetail($slug: [String]!) {
         }
     }
     entries(
-        section: "article"
+        section: ["article", "externalArticle"]
         relatedToEntries: { section: "staffMember", slug: $slug }
     ) {
-        ... on article_article_Entry {
-            id
-            title
-            to: uri
-            externalResourceUrl
-            heroImage {
-                ... on heroImage_heroImage_BlockType {
-                    id
-                    image {
-                        ...Image
-                    }
-                    altText
-                }
-            }
-
-            authors: staffMember {
+        id
+        title
+        to: uri
+        externalResourceUrl
+        heroImage {
+            ... on heroImage_heroImage_BlockType {
                 id
-                slug
-                to: uri
-                title
+                image {
+                    ...Image
+                }
+                altText
             }
-            description: summary
-            category: typeHandle
-            date: dateUpdated
         }
+
+        authors: staffMember {
+            id
+            slug
+            to: uri
+            title
+        }
+        description: summary
+        category: typeHandle
+        date: dateUpdated
     }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,11 @@
     "@nuxt/scripts": "1.2.1",
     "@nuxtjs/eslint-config-typescript": "^12.1.0",
     "@types/node": "^18.17.3",
+<<<<<<< HEAD
     "@ucla-library/component-library-nuxt-module": "1.4.1",
+=======
+    "@ucla-library/component-library-nuxt-module": "1.4.0",
+>>>>>>> c2be5475 (feat: update component-library-nuxt-module to 1.4.0)
     "@unhead/vue": "^2.1.15",
     "axe-core": "^4.12.1",
     "chromatic": "^13.3.5",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@nuxtjs/sitemap": "^5.3.5",
     "@pinia/nuxt": "^0.5.5",
     "@vue-a11y/skip-to": "^3.0.3",
-    "component-library-nuxt-module": "link:../../../../ucla-library-website-components/packages/component-library-nuxt-module",
     "graphql-tag": "^2.12.6",
     "vue": "^3.5.12",
     "vue-router": "^4.4.5"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@nuxtjs/sitemap": "^5.3.5",
     "@pinia/nuxt": "^0.5.5",
     "@vue-a11y/skip-to": "^3.0.3",
+    "component-library-nuxt-module": "link:../../../../ucla-library-website-components/packages/component-library-nuxt-module",
     "graphql-tag": "^2.12.6",
     "vue": "^3.5.12",
     "vue-router": "^4.4.5"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@nuxt/scripts": "1.2.1",
     "@nuxtjs/eslint-config-typescript": "^12.1.0",
     "@types/node": "^18.17.3",
-    "@ucla-library/component-library-nuxt-module": "1.4.1",
+    "@ucla-library/component-library-nuxt-module": "1.4.2",
     "@unhead/vue": "^2.1.15",
     "axe-core": "^4.12.1",
     "chromatic": "^13.3.5",

--- a/package.json
+++ b/package.json
@@ -32,11 +32,7 @@
     "@nuxt/scripts": "1.2.1",
     "@nuxtjs/eslint-config-typescript": "^12.1.0",
     "@types/node": "^18.17.3",
-<<<<<<< HEAD
     "@ucla-library/component-library-nuxt-module": "1.4.1",
-=======
-    "@ucla-library/component-library-nuxt-module": "1.4.0",
->>>>>>> c2be5475 (feat: update component-library-nuxt-module to 1.4.0)
     "@unhead/vue": "^2.1.15",
     "axe-core": "^4.12.1",
     "chromatic": "^13.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@vue-a11y/skip-to':
         specifier: ^3.0.3
         version: 3.0.3(vue@3.5.39(typescript@5.9.3))
-      component-library-nuxt-module:
-        specifier: link:../../../../ucla-library-website-components/packages/component-library-nuxt-module
-        version: link:../../../../ucla-library-website-components/packages/component-library-nuxt-module
       graphql-tag:
         specifier: ^2.12.6
         version: 2.12.7(graphql@16.14.2)
@@ -46,8 +43,8 @@ importers:
         specifier: ^18.17.3
         version: 18.19.130
       '@ucla-library/component-library-nuxt-module':
-        specifier: 1.4.2
-        version: 1.4.2(magicast@0.5.3)(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))
+        specifier: 1.4.1
+        version: 1.4.1(magicast@0.5.3)(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))
       '@unhead/vue':
         specifier: ^2.1.15
         version: 2.1.15(vue@3.5.39(typescript@5.9.3))
@@ -2995,15 +2992,15 @@ packages:
     resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
-  '@ucla-library-monorepo/ucla-library-website-components@1.80.0':
-    resolution: {integrity: sha512-pUKfeOmpQGqqWn2Kh7I+cMMpLwKFHLrprwoNRfzrrvPywPypZiSMUtgZKEOT0gL6qKJUv+rCV/4a08+tTEtB7Q==}
+  '@ucla-library-monorepo/ucla-library-website-components@1.79.1':
+    resolution: {integrity: sha512-3tZCZf9wB51ZTruRerOTw4Fnbfs/Pk+SuFiWBCrWRG4SkxdllLEf66tZNV6x2P2vP4X66ISwOHcPPMvtj5lMFA==}
     engines: {node: ^24.16.0, pnpm: ^11.5.1}
     peerDependencies:
       vue: ^3.5.12
       vuetify: 3.7.4
 
-  '@ucla-library/component-library-nuxt-module@1.4.2':
-    resolution: {integrity: sha512-IpXk/0oe9bbCDaMi1SOURtnoetU8LObEjFYkzJkkucc5hjxtmhikLipjRV7AOVASFh6CV+HqoCUK2PxIqWxlRg==}
+  '@ucla-library/component-library-nuxt-module@1.4.1':
+    resolution: {integrity: sha512-LWbTcdgClGJligJ5lRTiMtSQ44/pFFUGDWUdpEYEy/4TBIcRhxBLVmHGPTEY7HSujSrJ3tZL1qMOmJwj61gi7w==}
     engines: {node: ^24.16.0, pnpm: ^11.5.1}
 
   '@ungap/structured-clone@1.3.2':
@@ -3392,8 +3389,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  add-to-calendar-button@2.15.0:
-    resolution: {integrity: sha512-NzWgWLQv0FsJmYXCDku14FhxtLXG6OWK5l+foLz5WetZnbnPHQ879aYODHounQc0sxiwhKjjgIOQq0kDAvLRvA==}
+  add-to-calendar-button@2.14.0:
+    resolution: {integrity: sha512-2zVz1xm1AoaGKdZrRHIBNfB3fDL3xpfyRy8uUDJzzCp0b5zBJlmrv6zaJ7PO2XciJIaQvg3wvdWkiJ2LJ/P4gQ==}
     engines: {node: '>=18.17.0', npm: '>=9.6.7'}
 
   agent-base@6.0.2:
@@ -8814,8 +8811,8 @@ packages:
     resolution: {integrity: sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==}
     engines: {node: '>=4'}
 
-  timezones-ical-library@2.3.1:
-    resolution: {integrity: sha512-CUwoh7kQik+oy1YIl4+Mwrx5xCRO0n2+c6y0OpQf0l/tCJjNJomGQMK6CeLKSjACapp6bcn944wzGDEqJbk2aw==}
+  timezones-ical-library@2.2.1:
+    resolution: {integrity: sha512-VfDloy50AHsckqwuqc2ea+uyqxY7RjKXOqFMBd4T1zLkq31aVQNKhASvIF4+hSE2tuqaUGzGi4UQk5VzVNn94A==}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -10777,7 +10774,7 @@ snapshots:
       find-up: 6.3.0
       minimatch: 9.0.9
       read-pkg: 7.1.0
-      semver: 7.8.5
+      semver: 7.6.3
       yaml: 2.9.0
       yargs: 17.7.3
 
@@ -10833,7 +10830,7 @@ snapshots:
       resolve: 2.0.0-next.7
       rfdc: 1.4.1
       safe-json-stringify: 1.2.0
-      semver: 7.8.5
+      semver: 7.6.3
       string-width: 5.1.2
       strip-ansi: 7.2.0
       supports-color: 9.4.0
@@ -10912,7 +10909,7 @@ snapshots:
       p-retry: 5.1.2
       p-wait-for: 4.1.0
       path-key: 4.0.0
-      semver: 7.8.5
+      semver: 7.6.3
       tmp-promise: 3.0.3
       urlpattern-polyfill: 8.0.2
       uuid: 9.0.1
@@ -11105,7 +11102,7 @@ snapshots:
       precinct: 11.0.5(supports-color@9.4.0)
       require-package-name: 2.0.1
       resolve: 2.0.0-next.7
-      semver: 7.8.5
+      semver: 7.6.3
       tmp-promise: 3.0.3
       toml: 3.0.0
       unixify: 1.0.0
@@ -12722,12 +12719,12 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       eslint-visitor-keys: 3.4.3
 
-  '@ucla-library-monorepo/ucla-library-website-components@1.80.0(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))':
+  '@ucla-library-monorepo/ucla-library-website-components@1.79.1(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))':
     dependencies:
       '@vuepic/vue-datepicker': 8.8.1(vue@3.5.39(typescript@5.9.3))
       '@vueuse/components': 11.3.0(vue@3.5.39(typescript@5.9.3))
       '@vueuse/core': 11.3.0(vue@3.5.39(typescript@5.9.3))
-      add-to-calendar-button: 2.15.0
+      add-to-calendar-button: 2.14.0
       date-fns: 2.30.0
       lodash: 4.18.1
       pinia: 2.3.1(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))
@@ -12738,10 +12735,10 @@ snapshots:
       - '@vue/composition-api'
       - typescript
 
-  '@ucla-library/component-library-nuxt-module@1.4.2(magicast@0.5.3)(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))':
+  '@ucla-library/component-library-nuxt-module@1.4.1(magicast@0.5.3)(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))':
     dependencies:
       '@nuxt/kit': 3.21.8(magicast@0.5.3)
-      '@ucla-library-monorepo/ucla-library-website-components': 1.80.0(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))
+      '@ucla-library-monorepo/ucla-library-website-components': 1.79.1(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - magicast
@@ -13245,9 +13242,9 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  add-to-calendar-button@2.15.0:
+  add-to-calendar-button@2.14.0:
     dependencies:
-      timezones-ical-library: 2.3.1
+      timezones-ical-library: 2.2.1
 
   agent-base@6.0.2(supports-color@9.4.0):
     dependencies:
@@ -13319,7 +13316,7 @@ snapshots:
       global-cache-dir: 4.4.0
       is-plain-obj: 4.1.0
       path-exists: 5.0.0
-      semver: 7.8.5
+      semver: 7.6.3
       write-file-atomic: 4.0.2
 
   ansi-align@3.0.1:
@@ -14123,7 +14120,7 @@ snapshots:
       js-string-escape: 1.0.1
       lodash: 4.18.1
       md5-hex: 3.0.1
-      semver: 7.8.5
+      semver: 7.6.3
       well-known-symbols: 2.0.0
 
   confbox@0.1.8: {}
@@ -15506,7 +15503,7 @@ snapshots:
       proxy-addr: 2.0.7
       rfdc: 1.4.1
       secure-json-parse: 2.7.0
-      semver: 7.8.5
+      semver: 7.6.3
       toad-cache: 3.7.1
 
   fastq@1.20.1:
@@ -15832,7 +15829,7 @@ snapshots:
     dependencies:
       '@xhmikosr/downloader': 13.0.1
       node-fetch: 3.3.2
-      semver: 7.8.5
+      semver: 7.6.3
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -16682,7 +16679,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.8.5
+      semver: 7.6.3
 
   jsprim@2.0.2:
     dependencies:
@@ -17534,7 +17531,7 @@ snapshots:
       is-plain-obj: 4.1.0
       normalize-node-version: 12.4.0
       path-exists: 5.0.0
-      semver: 7.8.5
+      semver: 7.6.3
 
   nopt@5.0.0:
     dependencies:
@@ -17548,7 +17545,7 @@ snapshots:
     dependencies:
       all-node-versions: 11.3.0
       filter-obj: 5.1.0
-      semver: 7.8.5
+      semver: 7.6.3
 
   normalize-package-data@2.5.0:
     dependencies:
@@ -19136,7 +19133,7 @@ snapshots:
       detect-libc: 2.1.2
       node-addon-api: 6.1.0
       prebuild-install: 7.1.3
-      semver: 7.8.5
+      semver: 7.6.3
       simple-get: 4.0.1
       tar-fs: 3.1.3
       tunnel-agent: 0.6.0
@@ -19677,7 +19674,7 @@ snapshots:
 
   time-zone@1.0.0: {}
 
-  timezones-ical-library@2.3.1: {}
+  timezones-ical-library@2.2.1: {}
 
   tiny-invariant@1.3.3: {}
 
@@ -20145,7 +20142,7 @@ snapshots:
       is-npm: 6.1.0
       latest-version: 9.0.0
       pupa: 3.3.0
-      semver: 7.8.5
+      semver: 7.6.3
       xdg-basedir: 5.1.0
 
   uqr@0.1.3: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,13 @@ importers:
         specifier: ^18.17.3
         version: 18.19.130
       '@ucla-library/component-library-nuxt-module':
+<<<<<<< HEAD
         specifier: 1.4.1
         version: 1.4.1(magicast@0.5.3)(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))
+=======
+        specifier: 1.4.0
+        version: 1.4.0(magicast@0.5.3)(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))
+>>>>>>> c2be5475 (feat: update component-library-nuxt-module to 1.4.0)
       '@unhead/vue':
         specifier: ^2.1.15
         version: 2.1.15(vue@3.5.39(typescript@5.9.3))
@@ -2992,15 +2997,25 @@ packages:
     resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
+<<<<<<< HEAD
   '@ucla-library-monorepo/ucla-library-website-components@1.79.1':
     resolution: {integrity: sha512-3tZCZf9wB51ZTruRerOTw4Fnbfs/Pk+SuFiWBCrWRG4SkxdllLEf66tZNV6x2P2vP4X66ISwOHcPPMvtj5lMFA==}
+=======
+  '@ucla-library-monorepo/ucla-library-website-components@1.79.0':
+    resolution: {integrity: sha512-JVMg01tXbZRPiVYzRMmOmuvmcuomPjPznK62XJ8jndWkjip5d20Al0MkzmbByEscPN4C8W3KRs1zsphY5UcgzQ==}
+>>>>>>> c2be5475 (feat: update component-library-nuxt-module to 1.4.0)
     engines: {node: ^24.16.0, pnpm: ^11.5.1}
     peerDependencies:
       vue: ^3.5.12
       vuetify: 3.7.4
 
+<<<<<<< HEAD
   '@ucla-library/component-library-nuxt-module@1.4.1':
     resolution: {integrity: sha512-LWbTcdgClGJligJ5lRTiMtSQ44/pFFUGDWUdpEYEy/4TBIcRhxBLVmHGPTEY7HSujSrJ3tZL1qMOmJwj61gi7w==}
+=======
+  '@ucla-library/component-library-nuxt-module@1.4.0':
+    resolution: {integrity: sha512-1hK0TskaXVf4UXj15FXs9MJ7c4kQW6f39G+n6C3fFJP6C+lXLnXd0EYIyfdDRCVmUJJijwcvwuYaYdgOBkeDjw==}
+>>>>>>> c2be5475 (feat: update component-library-nuxt-module to 1.4.0)
     engines: {node: ^24.16.0, pnpm: ^11.5.1}
 
   '@ungap/structured-clone@1.3.2':
@@ -12719,7 +12734,11 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       eslint-visitor-keys: 3.4.3
 
+<<<<<<< HEAD
   '@ucla-library-monorepo/ucla-library-website-components@1.79.1(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))':
+=======
+  '@ucla-library-monorepo/ucla-library-website-components@1.79.0(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))':
+>>>>>>> c2be5475 (feat: update component-library-nuxt-module to 1.4.0)
     dependencies:
       '@vuepic/vue-datepicker': 8.8.1(vue@3.5.39(typescript@5.9.3))
       '@vueuse/components': 11.3.0(vue@3.5.39(typescript@5.9.3))
@@ -12735,10 +12754,17 @@ snapshots:
       - '@vue/composition-api'
       - typescript
 
+<<<<<<< HEAD
   '@ucla-library/component-library-nuxt-module@1.4.1(magicast@0.5.3)(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))':
     dependencies:
       '@nuxt/kit': 3.21.8(magicast@0.5.3)
       '@ucla-library-monorepo/ucla-library-website-components': 1.79.1(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))
+=======
+  '@ucla-library/component-library-nuxt-module@1.4.0(magicast@0.5.3)(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))':
+    dependencies:
+      '@nuxt/kit': 3.21.8(magicast@0.5.3)
+      '@ucla-library-monorepo/ucla-library-website-components': 1.79.0(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))
+>>>>>>> c2be5475 (feat: update component-library-nuxt-module to 1.4.0)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - magicast
@@ -13316,7 +13342,7 @@ snapshots:
       global-cache-dir: 4.4.0
       is-plain-obj: 4.1.0
       path-exists: 5.0.0
-      semver: 7.6.3
+      semver: 7.8.5
       write-file-atomic: 4.0.2
 
   ansi-align@3.0.1:
@@ -17545,7 +17571,7 @@ snapshots:
     dependencies:
       all-node-versions: 11.3.0
       filter-obj: 5.1.0
-      semver: 7.6.3
+      semver: 7.8.5
 
   normalize-package-data@2.5.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: ^18.17.3
         version: 18.19.130
       '@ucla-library/component-library-nuxt-module':
-        specifier: 1.4.1
-        version: 1.4.1(magicast@0.5.3)(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))
+        specifier: 1.4.2
+        version: 1.4.2(magicast@0.5.3)(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))
       '@unhead/vue':
         specifier: ^2.1.15
         version: 2.1.15(vue@3.5.39(typescript@5.9.3))
@@ -2992,15 +2992,15 @@ packages:
     resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
-  '@ucla-library-monorepo/ucla-library-website-components@1.79.1':
-    resolution: {integrity: sha512-3tZCZf9wB51ZTruRerOTw4Fnbfs/Pk+SuFiWBCrWRG4SkxdllLEf66tZNV6x2P2vP4X66ISwOHcPPMvtj5lMFA==}
+  '@ucla-library-monorepo/ucla-library-website-components@1.80.0':
+    resolution: {integrity: sha512-pUKfeOmpQGqqWn2Kh7I+cMMpLwKFHLrprwoNRfzrrvPywPypZiSMUtgZKEOT0gL6qKJUv+rCV/4a08+tTEtB7Q==}
     engines: {node: ^24.16.0, pnpm: ^11.5.1}
     peerDependencies:
       vue: ^3.5.12
       vuetify: 3.7.4
 
-  '@ucla-library/component-library-nuxt-module@1.4.1':
-    resolution: {integrity: sha512-LWbTcdgClGJligJ5lRTiMtSQ44/pFFUGDWUdpEYEy/4TBIcRhxBLVmHGPTEY7HSujSrJ3tZL1qMOmJwj61gi7w==}
+  '@ucla-library/component-library-nuxt-module@1.4.2':
+    resolution: {integrity: sha512-IpXk/0oe9bbCDaMi1SOURtnoetU8LObEjFYkzJkkucc5hjxtmhikLipjRV7AOVASFh6CV+HqoCUK2PxIqWxlRg==}
     engines: {node: ^24.16.0, pnpm: ^11.5.1}
 
   '@ungap/structured-clone@1.3.2':
@@ -12719,7 +12719,7 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       eslint-visitor-keys: 3.4.3
 
-  '@ucla-library-monorepo/ucla-library-website-components@1.79.1(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))':
+  '@ucla-library-monorepo/ucla-library-website-components@1.80.0(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))':
     dependencies:
       '@vuepic/vue-datepicker': 8.8.1(vue@3.5.39(typescript@5.9.3))
       '@vueuse/components': 11.3.0(vue@3.5.39(typescript@5.9.3))
@@ -12735,10 +12735,10 @@ snapshots:
       - '@vue/composition-api'
       - typescript
 
-  '@ucla-library/component-library-nuxt-module@1.4.1(magicast@0.5.3)(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))':
+  '@ucla-library/component-library-nuxt-module@1.4.2(magicast@0.5.3)(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))':
     dependencies:
       '@nuxt/kit': 3.21.8(magicast@0.5.3)
-      '@ucla-library-monorepo/ucla-library-website-components': 1.79.1(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))
+      '@ucla-library-monorepo/ucla-library-website-components': 1.80.0(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - magicast
@@ -13316,7 +13316,7 @@ snapshots:
       global-cache-dir: 4.4.0
       is-plain-obj: 4.1.0
       path-exists: 5.0.0
-      semver: 7.6.3
+      semver: 7.8.5
       write-file-atomic: 4.0.2
 
   ansi-align@3.0.1:
@@ -17545,7 +17545,7 @@ snapshots:
     dependencies:
       all-node-versions: 11.3.0
       filter-obj: 5.1.0
-      semver: 7.6.3
+      semver: 7.8.5
 
   normalize-package-data@2.5.0:
     dependencies:
@@ -19133,7 +19133,7 @@ snapshots:
       detect-libc: 2.1.2
       node-addon-api: 6.1.0
       prebuild-install: 7.1.3
-      semver: 7.6.3
+      semver: 7.8.5
       simple-get: 4.0.1
       tar-fs: 3.1.3
       tunnel-agent: 0.6.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^18.17.3
         version: 18.19.130
       '@ucla-library/component-library-nuxt-module':
-        specifier: 1.4.1
-        version: 1.4.1(magicast@0.5.3)(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))
+        specifier: 1.4.2
+        version: 1.4.2(magicast@0.5.3)(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))
       '@unhead/vue':
         specifier: ^2.1.15
         version: 2.1.15(vue@3.5.39(typescript@5.9.3))
@@ -2995,15 +2995,15 @@ packages:
     resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
-  '@ucla-library-monorepo/ucla-library-website-components@1.79.1':
-    resolution: {integrity: sha512-3tZCZf9wB51ZTruRerOTw4Fnbfs/Pk+SuFiWBCrWRG4SkxdllLEf66tZNV6x2P2vP4X66ISwOHcPPMvtj5lMFA==}
+  '@ucla-library-monorepo/ucla-library-website-components@1.80.0':
+    resolution: {integrity: sha512-pUKfeOmpQGqqWn2Kh7I+cMMpLwKFHLrprwoNRfzrrvPywPypZiSMUtgZKEOT0gL6qKJUv+rCV/4a08+tTEtB7Q==}
     engines: {node: ^24.16.0, pnpm: ^11.5.1}
     peerDependencies:
       vue: ^3.5.12
       vuetify: 3.7.4
 
-  '@ucla-library/component-library-nuxt-module@1.4.1':
-    resolution: {integrity: sha512-LWbTcdgClGJligJ5lRTiMtSQ44/pFFUGDWUdpEYEy/4TBIcRhxBLVmHGPTEY7HSujSrJ3tZL1qMOmJwj61gi7w==}
+  '@ucla-library/component-library-nuxt-module@1.4.2':
+    resolution: {integrity: sha512-IpXk/0oe9bbCDaMi1SOURtnoetU8LObEjFYkzJkkucc5hjxtmhikLipjRV7AOVASFh6CV+HqoCUK2PxIqWxlRg==}
     engines: {node: ^24.16.0, pnpm: ^11.5.1}
 
   '@ungap/structured-clone@1.3.2':
@@ -12722,7 +12722,7 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       eslint-visitor-keys: 3.4.3
 
-  '@ucla-library-monorepo/ucla-library-website-components@1.79.1(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))':
+  '@ucla-library-monorepo/ucla-library-website-components@1.80.0(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))':
     dependencies:
       '@vuepic/vue-datepicker': 8.8.1(vue@3.5.39(typescript@5.9.3))
       '@vueuse/components': 11.3.0(vue@3.5.39(typescript@5.9.3))
@@ -12738,10 +12738,10 @@ snapshots:
       - '@vue/composition-api'
       - typescript
 
-  '@ucla-library/component-library-nuxt-module@1.4.1(magicast@0.5.3)(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))':
+  '@ucla-library/component-library-nuxt-module@1.4.2(magicast@0.5.3)(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))':
     dependencies:
       '@nuxt/kit': 3.21.8(magicast@0.5.3)
-      '@ucla-library-monorepo/ucla-library-website-components': 1.79.1(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))
+      '@ucla-library-monorepo/ucla-library-website-components': 1.80.0(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - magicast

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,13 +43,8 @@ importers:
         specifier: ^18.17.3
         version: 18.19.130
       '@ucla-library/component-library-nuxt-module':
-<<<<<<< HEAD
         specifier: 1.4.1
         version: 1.4.1(magicast@0.5.3)(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))
-=======
-        specifier: 1.4.0
-        version: 1.4.0(magicast@0.5.3)(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))
->>>>>>> c2be5475 (feat: update component-library-nuxt-module to 1.4.0)
       '@unhead/vue':
         specifier: ^2.1.15
         version: 2.1.15(vue@3.5.39(typescript@5.9.3))
@@ -2997,25 +2992,15 @@ packages:
     resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
-<<<<<<< HEAD
   '@ucla-library-monorepo/ucla-library-website-components@1.79.1':
     resolution: {integrity: sha512-3tZCZf9wB51ZTruRerOTw4Fnbfs/Pk+SuFiWBCrWRG4SkxdllLEf66tZNV6x2P2vP4X66ISwOHcPPMvtj5lMFA==}
-=======
-  '@ucla-library-monorepo/ucla-library-website-components@1.79.0':
-    resolution: {integrity: sha512-JVMg01tXbZRPiVYzRMmOmuvmcuomPjPznK62XJ8jndWkjip5d20Al0MkzmbByEscPN4C8W3KRs1zsphY5UcgzQ==}
->>>>>>> c2be5475 (feat: update component-library-nuxt-module to 1.4.0)
     engines: {node: ^24.16.0, pnpm: ^11.5.1}
     peerDependencies:
       vue: ^3.5.12
       vuetify: 3.7.4
 
-<<<<<<< HEAD
   '@ucla-library/component-library-nuxt-module@1.4.1':
     resolution: {integrity: sha512-LWbTcdgClGJligJ5lRTiMtSQ44/pFFUGDWUdpEYEy/4TBIcRhxBLVmHGPTEY7HSujSrJ3tZL1qMOmJwj61gi7w==}
-=======
-  '@ucla-library/component-library-nuxt-module@1.4.0':
-    resolution: {integrity: sha512-1hK0TskaXVf4UXj15FXs9MJ7c4kQW6f39G+n6C3fFJP6C+lXLnXd0EYIyfdDRCVmUJJijwcvwuYaYdgOBkeDjw==}
->>>>>>> c2be5475 (feat: update component-library-nuxt-module to 1.4.0)
     engines: {node: ^24.16.0, pnpm: ^11.5.1}
 
   '@ungap/structured-clone@1.3.2':
@@ -10789,7 +10774,7 @@ snapshots:
       find-up: 6.3.0
       minimatch: 9.0.9
       read-pkg: 7.1.0
-      semver: 7.6.3
+      semver: 7.8.5
       yaml: 2.9.0
       yargs: 17.7.3
 
@@ -10845,7 +10830,7 @@ snapshots:
       resolve: 2.0.0-next.7
       rfdc: 1.4.1
       safe-json-stringify: 1.2.0
-      semver: 7.6.3
+      semver: 7.8.5
       string-width: 5.1.2
       strip-ansi: 7.2.0
       supports-color: 9.4.0
@@ -10924,7 +10909,7 @@ snapshots:
       p-retry: 5.1.2
       p-wait-for: 4.1.0
       path-key: 4.0.0
-      semver: 7.6.3
+      semver: 7.8.5
       tmp-promise: 3.0.3
       urlpattern-polyfill: 8.0.2
       uuid: 9.0.1
@@ -11117,7 +11102,7 @@ snapshots:
       precinct: 11.0.5(supports-color@9.4.0)
       require-package-name: 2.0.1
       resolve: 2.0.0-next.7
-      semver: 7.6.3
+      semver: 7.8.5
       tmp-promise: 3.0.3
       toml: 3.0.0
       unixify: 1.0.0
@@ -12734,11 +12719,7 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       eslint-visitor-keys: 3.4.3
 
-<<<<<<< HEAD
   '@ucla-library-monorepo/ucla-library-website-components@1.79.1(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))':
-=======
-  '@ucla-library-monorepo/ucla-library-website-components@1.79.0(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))':
->>>>>>> c2be5475 (feat: update component-library-nuxt-module to 1.4.0)
     dependencies:
       '@vuepic/vue-datepicker': 8.8.1(vue@3.5.39(typescript@5.9.3))
       '@vueuse/components': 11.3.0(vue@3.5.39(typescript@5.9.3))
@@ -12754,17 +12735,10 @@ snapshots:
       - '@vue/composition-api'
       - typescript
 
-<<<<<<< HEAD
   '@ucla-library/component-library-nuxt-module@1.4.1(magicast@0.5.3)(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))':
     dependencies:
       '@nuxt/kit': 3.21.8(magicast@0.5.3)
       '@ucla-library-monorepo/ucla-library-website-components': 1.79.1(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))
-=======
-  '@ucla-library/component-library-nuxt-module@1.4.0(magicast@0.5.3)(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))':
-    dependencies:
-      '@nuxt/kit': 3.21.8(magicast@0.5.3)
-      '@ucla-library-monorepo/ucla-library-website-components': 1.79.0(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))(vuetify@3.7.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))
->>>>>>> c2be5475 (feat: update component-library-nuxt-module to 1.4.0)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - magicast
@@ -14146,7 +14120,7 @@ snapshots:
       js-string-escape: 1.0.1
       lodash: 4.18.1
       md5-hex: 3.0.1
-      semver: 7.6.3
+      semver: 7.8.5
       well-known-symbols: 2.0.0
 
   confbox@0.1.8: {}
@@ -15529,7 +15503,7 @@ snapshots:
       proxy-addr: 2.0.7
       rfdc: 1.4.1
       secure-json-parse: 2.7.0
-      semver: 7.6.3
+      semver: 7.8.5
       toad-cache: 3.7.1
 
   fastq@1.20.1:
@@ -15855,7 +15829,7 @@ snapshots:
     dependencies:
       '@xhmikosr/downloader': 13.0.1
       node-fetch: 3.3.2
-      semver: 7.6.3
+      semver: 7.8.5
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -16705,7 +16679,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.6.3
+      semver: 7.8.5
 
   jsprim@2.0.2:
     dependencies:
@@ -17557,7 +17531,7 @@ snapshots:
       is-plain-obj: 4.1.0
       normalize-node-version: 12.4.0
       path-exists: 5.0.0
-      semver: 7.6.3
+      semver: 7.8.5
 
   nopt@5.0.0:
     dependencies:
@@ -19159,7 +19133,7 @@ snapshots:
       detect-libc: 2.1.2
       node-addon-api: 6.1.0
       prebuild-install: 7.1.3
-      semver: 7.6.3
+      semver: 7.8.5
       simple-get: 4.0.1
       tar-fs: 3.1.3
       tunnel-agent: 0.6.0
@@ -20168,7 +20142,7 @@ snapshots:
       is-npm: 6.1.0
       latest-version: 9.0.0
       pupa: 3.3.0
-      semver: 7.6.3
+      semver: 7.8.5
       xdg-basedir: 5.1.0
 
   uqr@0.1.3: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@vue-a11y/skip-to':
         specifier: ^3.0.3
         version: 3.0.3(vue@3.5.39(typescript@5.9.3))
+      component-library-nuxt-module:
+        specifier: link:../../../../ucla-library-website-components/packages/component-library-nuxt-module
+        version: link:../../../../ucla-library-website-components/packages/component-library-nuxt-module
       graphql-tag:
         specifier: ^2.12.6
         version: 2.12.7(graphql@16.14.2)
@@ -3389,8 +3392,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  add-to-calendar-button@2.14.0:
-    resolution: {integrity: sha512-2zVz1xm1AoaGKdZrRHIBNfB3fDL3xpfyRy8uUDJzzCp0b5zBJlmrv6zaJ7PO2XciJIaQvg3wvdWkiJ2LJ/P4gQ==}
+  add-to-calendar-button@2.15.0:
+    resolution: {integrity: sha512-NzWgWLQv0FsJmYXCDku14FhxtLXG6OWK5l+foLz5WetZnbnPHQ879aYODHounQc0sxiwhKjjgIOQq0kDAvLRvA==}
     engines: {node: '>=18.17.0', npm: '>=9.6.7'}
 
   agent-base@6.0.2:
@@ -8811,8 +8814,8 @@ packages:
     resolution: {integrity: sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==}
     engines: {node: '>=4'}
 
-  timezones-ical-library@2.2.1:
-    resolution: {integrity: sha512-VfDloy50AHsckqwuqc2ea+uyqxY7RjKXOqFMBd4T1zLkq31aVQNKhASvIF4+hSE2tuqaUGzGi4UQk5VzVNn94A==}
+  timezones-ical-library@2.3.1:
+    resolution: {integrity: sha512-CUwoh7kQik+oy1YIl4+Mwrx5xCRO0n2+c6y0OpQf0l/tCJjNJomGQMK6CeLKSjACapp6bcn944wzGDEqJbk2aw==}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -12724,7 +12727,7 @@ snapshots:
       '@vuepic/vue-datepicker': 8.8.1(vue@3.5.39(typescript@5.9.3))
       '@vueuse/components': 11.3.0(vue@3.5.39(typescript@5.9.3))
       '@vueuse/core': 11.3.0(vue@3.5.39(typescript@5.9.3))
-      add-to-calendar-button: 2.14.0
+      add-to-calendar-button: 2.15.0
       date-fns: 2.30.0
       lodash: 4.18.1
       pinia: 2.3.1(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))
@@ -13242,9 +13245,9 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  add-to-calendar-button@2.14.0:
+  add-to-calendar-button@2.15.0:
     dependencies:
-      timezones-ical-library: 2.2.1
+      timezones-ical-library: 2.3.1
 
   agent-base@6.0.2(supports-color@9.4.0):
     dependencies:
@@ -19674,7 +19677,7 @@ snapshots:
 
   time-zone@1.0.0: {}
 
-  timezones-ical-library@2.2.1: {}
+  timezones-ical-library@2.3.1: {}
 
   tiny-invariant@1.3.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,12 +9,5 @@ allowBuilds:
   vue-demi: true
 engineStrict: true
 minimumReleaseAgeExclude:
-<<<<<<< HEAD
   - '@ucla-library-monorepo/ucla-library-website-components@1.79.1'
   - '@ucla-library/component-library-nuxt-module@1.4.1'
-=======
-  - '@ucla-library-monorepo/ucla-library-website-components@1.78.2'
-  - '@ucla-library/component-library-nuxt-module@1.3.50'
-  - '@ucla-library-monorepo/ucla-library-website-components@1.79.0'
-  - '@ucla-library/component-library-nuxt-module@1.4.0'
->>>>>>> c2be5475 (feat: update component-library-nuxt-module to 1.4.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,5 +9,12 @@ allowBuilds:
   vue-demi: true
 engineStrict: true
 minimumReleaseAgeExclude:
+<<<<<<< HEAD
   - '@ucla-library-monorepo/ucla-library-website-components@1.79.1'
   - '@ucla-library/component-library-nuxt-module@1.4.1'
+=======
+  - '@ucla-library-monorepo/ucla-library-website-components@1.78.2'
+  - '@ucla-library/component-library-nuxt-module@1.3.50'
+  - '@ucla-library-monorepo/ucla-library-website-components@1.79.0'
+  - '@ucla-library/component-library-nuxt-module@1.4.0'
+>>>>>>> c2be5475 (feat: update component-library-nuxt-module to 1.4.0)


### PR DESCRIPTION
#### Connected to [LADI-5240](https://jira.library.ucla.edu/browse/LADI-5240)

#### Deployed on https://deploy-preview-937--uclalibrary-test.netlify.app/

---

### Notes

https://deploy-preview-937--uclalibrary-test.netlify.app/

Following the creation of the External Article entry type in Craft CMS ([LADI-5173](https://uclalibrary.atlassian.net/browse/LADI-5173)), this ticket covers the Nuxt frontend implementation. External Articles must surface in listings, homepage features, and associated content with links going directly to the externalResourceUrl — no detail page template should be generated for them.

### Dependencies:
1. - [x] [LADI-5173: Create External Article Entry Type in Craft CMS](https://github.com/UCLALibrary/craftcms/pull/342)
    + https://github.com/UCLALibrary/craftcms/pull/342
2. - [x] [LADI-5145: Add redirects for newer Article entries with externalResourceUrl](https://uclalibrary.atlassian.net/browse/LADI-5145)
    + https://github.com/UCLALibrary/library-website-nuxt/pull/940
    + Backlog (redirects for already-indexed URLs)
    + Should be released at the same time as this ticket.
3. - [x] Component Library branch [LADI-5240_add-external-article-entry-type](https://github.com/UCLALibrary/ucla-library-website-components/pull/958)
4. - [x] Component Library branch LADI-5240-2_add-external-article-entry-type

### Update GraphQL queries on affected pages to include External Article entries.
1. - [x] article listing page `gql/queries/ArticleList.gql`
2. - [x] homepage (does not require updates)
3. - [x] search results
5. - [x] associated content contexts
    + - [x] staff detail page `gql/queries/StaffDetail.gql`
    + - [x] location detail page `gql/queries/LocationDetail.gql`
    + - [x] program detail page `gql/queries/ProgramDetail.gql`
    + - [x] collection listing page `gql/queries/CollectionsList.gql`

- [x] The externalResourceUrl field should be used as the link destination wherever External Articles appear.   -- However, the uri field for externalArticle pulls from externalResourceUrl and will have the same value.
- [x] Links to External Articles should open the external URL directly and open in a new tab.
- [x] Ensure no Nuxt route or static page is generated for External Article entries during the build — confirm how the new entry type is distinguished in the GraphQL schema from standard articles.

### Affected Contexts
1. News listing page 
    + https://deploy-preview-937--uclalibrary-test.netlify.app/about/news
    + https://test-craft.library.ucla.edu/admin/entries/listingNews/35878-listing-news
    + https://uclalibrary-test.library.ucla.edu/about/news/?preview=true
    + <img width="1070" height="532" alt="Screenshot 2026-06-26 at 2 04 38 PM" src="https://github.com/user-attachments/assets/42bc6830-5d60-4a05-8fe8-f8f4334e368c" />
2. Homepage featured news
    + https://deploy-preview-937--uclalibrary-test.netlify.app/
    + https://test-craft.library.ucla.edu/admin/entries/homepage/1589-homepage
    + https://uclalibrary-test.library.ucla.edu/?preview=true
    + Davenport California and Water Polo are both using the new External Article field and open in new windows
    + <img width="1072" height="597" alt="Screenshot 2026-07-01 at 10 48 32 AM" src="https://github.com/user-attachments/assets/35e18b94-d4dc-4bdf-b600-7ef299cd4758" />
3. Flexible page blocks with internal content
On the impact page ALL of the links are supposed to open in an external page. (_blank))
    + https://deploy-preview-937--uclalibrary-test.netlify.app/impact/2026
    + https://test-craft.library.ucla.edu/admin/entries/impactReport/4791933-2025
    + https://uclalibrary-test.library.ucla.edu/impact/2026?preview=true
    + <img width="673" height="545" alt="Screenshot 2026-07-01 at 1 34 38 PM" src="https://github.com/user-attachments/assets/0bf29fbe-5b92-4c7d-b26f-04e6f9e568b8" />
4. Impact report grid gallery / timeline
    + https://deploy-preview-937--uclalibrary-test.netlify.app/impact/2026
    + https://test-craft.library.ucla.edu/admin/entries/impactReport/4791933-2025
    + https://uclalibrary-test.library.ucla.edu/impact/2026?preview=true
    + <img width="695" height="532" alt="Screenshot 2026-07-01 at 1 36 00 PM" src="https://github.com/user-attachments/assets/cf69dce4-b32d-4a76-966e-ec3681458d17" />

### Associated content on relevant pages 
1. Staff detail page
    + https://deploy-preview-937--uclalibrary-test.netlify.app/about/staff/jason-burton
    + https://test-craft.library.ucla.edu/admin/entries/externalArticle/4979929-test-university-library-launches-digital-archives-collection-for-research-access
    + https://uclalibrary-test.library.ucla.edu/about/staff/jason-burton/?preview=true
    + <img width="940" height="450" alt="Screenshot 2026-07-02 at 4 09 02 PM" src="https://github.com/user-attachments/assets/2e67ac50-a2ff-446c-8cd1-1d64f341bfed" />
2. Location detail page
    + https://deploy-preview-937--uclalibrary-test.netlify.app/visit/locations/biomed
    + https://test-craft.library.ucla.edu/admin/entries/externalArticle/4979929-test-university-library-launches-digital-archives-collection-for-research-access
    + https://uclalibrary-test.library.ucla.edu/visit/locations/biomed?preview=true
    +  <img width="1039" height="588" alt="Screenshot 2026-07-22 at 5 11 32 PM" src="https://github.com/user-attachments/assets/f442b38d-824c-488d-8a9c-8659e5225fb8" />
    +  <img width="960" height="520" alt="Screenshot 2026-07-22 at 5 13 00 PM" src="https://github.com/user-attachments/assets/c52e2035-ffb7-4fe8-bfcf-1735067786d9" />
3. Program detail page
    + https://deploy-preview-937--uclalibrary-test.netlify.app/about/programs/digital-library-program
    + https://test-craft.library.ucla.edu/admin/entries/externalArticle/4979929-test-university-library-launches-digital-archives-collection-for-research-access
    + https://uclalibrary-test.library.ucla.edu/about/programs/digital-library-program?preview=true&x-craft-preview=rsrUcznblF&token=ZRTZIgJJAsi-4Z-g1UMpZRLvnu45IJ0K
    + Associated Topics
    + <img width="954" height="619" alt="Screenshot 2026-07-02 at 3 31 34 PM" src="https://github.com/user-attachments/assets/85d8e5ab-bec6-4a4f-9b04-7d18791d5fbf" />
    + Associated News
    + <img width="958" height="618" alt="Screenshot 2026-07-02 at 3 05 05 PM" src="https://github.com/user-attachments/assets/9060737e-b076-4db3-a03f-1e62c83ea0d4" />
4. Collection listing page
    + https://deploy-preview-937--uclalibrary-test.netlify.app/collections
    + https://test-craft.library.ucla.edu/admin/entries/externalArticle/4979929-test-university-library-launches-digital-archives-collection-for-research-access 
    + https://uclalibrary-test.library.ucla.edu/collections?preview=true
    + Associated Topics
    + <img width="966" height="559" alt="Screenshot 2026-07-02 at 3 33 35 PM" src="https://github.com/user-attachments/assets/3d2dc521-45b3-4ebe-add5-5078967e3b00" />
    + Collections News
    + <img width="989" height="611" alt="Screenshot 2026-07-02 at 3 34 32 PM" src="https://github.com/user-attachments/assets/96b16e1b-fe9d-43ca-8867-a71de64f90af" />
6. Site search results
    + https://deploy-preview-937--uclalibrary-test.netlify.app/search-site?q=TEST+University+Library+Launches+Digital+Archives+Collection+for+Research+Access
    + https://uclalibrary-test.library.ucla.edu/search-site?q=TEST+University+Library+Launches+Digital+Archives+Collection+for+Research+Access
<img width="1117" height="781" alt="Screenshot 2026-07-02 at 2 41 30 PM" src="https://github.com/user-attachments/assets/78751929-5125-4e16-a30e-370bbecc5277" />

---

#### Acceptance Criteria
- [x]  GraphQL queries on all affected contexts are updated to include External Article entries.
- [x]  External Articles appear in 
    - [x]  news listings
    - [x]  homepage
    - [x] flexible page blocks
    - [x] associated content
    - [x] search results
- [x] All links to External Articles resolve to externalResourceUrl — not to a local library page.
- [x] No static page or Nuxt route is generated for any External Article entry during the build.
- [x] No regression for standard article entries.
- [x] Verified in staging across all affected contexts before merging.

---

## Checklist

### Author
- [x] Browsers
    - [x] Review PR in Chrome, Firefox, Safari, Edge
    - [x] Review PR in desktop view, tablet view, mobile view
- [x] A11Y
    - [x] Zoom the site to 200%
    - [x] Check for keyboard traps
- [x] Design & Code
    - [x] Check that it looks like the design(s) _(if applicable)_
    - [x] Include a working / updated spec file _(if applicable)_
    - [ ] Review the Chromatic

### UX Review
- [ ] UX has reviewed and approved

### Dev Review
  - [ ] Review Chromatic
  - [ ] Review the deploy preview
  - [ ] Review the code


[LADI-5173]: https://uclalibrary.atlassian.net/browse/LADI-5173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LADI-5240]: https://uclalibrary.atlassian.net/browse/LADI-5240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ