### PR TITLE
feat: remove articles with external resource from the build 

### DIFF
--- a/app/middleware/redirect-external-news-clientonly.js
+++ b/app/middleware/redirect-external-news-clientonly.js
@@ -1,0 +1,20 @@
+import ARTICLE_DETAIL from '../gql/queries/ArticleDetail.gql'
+export default defineNuxtRouteMiddleware(async (to) => {
+  if (!import.meta.client) return
+  // Only run for /about/news/*
+  if (!to.path.startsWith('/about/news/')) return
+  const { $graphql } = useNuxtApp()
+
+  const data = await $graphql.default.request(ARTICLE_DETAIL, {
+    slug: to.params.slug
+  })
+
+  const url = data?.entry?.externalResourceUrl?.trim()
+
+  if (url) {
+    return navigateTo(url, {
+      external: true,
+      redirectCode: 301
+    })
+  }
+})

--- a/app/pages/about/news/[slug].vue
+++ b/app/pages/about/news/[slug].vue
@@ -35,6 +35,13 @@ if (!data.value.entry) {
   })
 }
 
+if (data.value.entry.externalResourceUrl?.trim()) {
+  await navigateTo(data.value.entry.externalResourceUrl, {
+    external: true,
+    redirectCode: 301
+  })
+}
+
 // console.log("import.meta.prerender", import.meta.prerender, process.client)
 
 if (data.value.entry.slug && import.meta.prerender) {

--- a/app/pages/about/news/[slug].vue
+++ b/app/pages/about/news/[slug].vue
@@ -11,7 +11,9 @@ import removeTags from '@/utils/removeTags'
 // GQL
 
 const route = useRoute()
-
+definePageMeta({
+  middleware: 'redirect-external-news-clientonly'
+})
 // console.log('In news Slug page')
 
 const { $graphql } = useNuxtApp()
@@ -35,12 +37,12 @@ if (!data.value.entry) {
   })
 }
 
-if (data.value.entry.externalResourceUrl?.trim()) {
+/* if (data.value.entry.externalResourceUrl?.trim()) {
   await navigateTo(data.value.entry.externalResourceUrl, {
     external: true,
     redirectCode: 301
   })
-}
+} */
 
 // console.log("import.meta.prerender", import.meta.prerender, process.client)
 

--- a/app/pages/about/news/index.vue
+++ b/app/pages/about/news/index.vue
@@ -40,6 +40,7 @@ if (data.value.entries && import.meta.prerender) {
     if (entry.externalResourceUrl?.trim() !== '') {
       entry.articleCategory = entry.category
       const { index } = useIndexer()
+      console.log('External Articles Indexing', entry, entry.slug)
       await index(entry, entry.slug)
     }
   }

--- a/app/pages/about/news/index.vue
+++ b/app/pages/about/news/index.vue
@@ -35,6 +35,16 @@ if (!data.value?.entry && !data.value?.entries) {
   throw createError({ statusCode: 404, message: 'Page not found', fatal: true })
 }
 
+if (data.value.entries && import.meta.prerender) {
+  for (const entry of data.value.entries) {
+    if (entry.externalResourceUrl?.trim() !== '') {
+      entry.articleCategory = entry.category
+      const { index } = useIndexer()
+      await index(entry, entry.slug)
+    }
+  }
+}
+
 if (data.value.entry && import.meta.prerender) {
   const { index } = useIndexer()
   const doc = {

--- a/gql/queries/ArticleList.gql
+++ b/gql/queries/ArticleList.gql
@@ -8,6 +8,8 @@ query ArticleList {
     ... on article_article_Entry {
       title
       to: uri
+      slug
+      sectionHandle
       externalResourceUrl
       heroImage {
         ... on heroImage_heroImage_BlockType {
@@ -46,6 +48,7 @@ query ArticleList {
             text: summary
             to: uri
             externalResourceUrl
+            sectionHandle
             heroImage {
               ... on heroImage_heroImage_BlockType {
                 id

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -146,7 +146,7 @@ export default defineNuxtConfig({
             'Content-Type': 'application/json'
           },
           method: 'POST',
-          body: JSON.stringify({ query: 'query AllPages { entries { uri, sectionHandle } }' })
+          body: JSON.stringify({ query: 'query AllPages { entries { uri, sectionHandle, externalResourceUrl } }' })
         })
 
         const postPages = await response.json()
@@ -156,9 +156,11 @@ export default defineNuxtConfig({
             !item.sectionHandle.includes('meap') && !item.sectionHandle.includes('ftva')
             && !item.sectionHandle.includes('organization') && !item.sectionHandle.includes('/__home__')
             && !item.sectionHandle.includes('visit/spaces') && !item.sectionHandle.includes('null')
+            && !(item.sectionHandle === 'article' && item.externalResourceUrl?.trim())
           ).map(entry => '/' + entry.uri)
 
           allRoutes.push(...postWithoutPayloadRoutes)
+          // console.log('prerender:routes postWithoutPayloadRoutes', postWithoutPayloadRoutes)
         }
 
         if (allRoutes.length) {


### PR DESCRIPTION
and add indexing of external resource articles in the listing page, and add a redirect if someone opens the URL or the slug in Craft preview

#### Connected to [LADI-5144](https://jira.library.ucla.edu/browse/LADI-5144)

#### Deployed on https://deploy-preview-938--uclalibrary-test.netlify.app

---

### Notes
This PR removes articles from Nuxt routes when articles have an external resource URL.
But we still need to index this content, so the indexing logic is added to the news index page template.
Another scenario is we want to redirect the page to an external resource URL field content if the page slug/uri is already bookmarked or in Craft cms previews


[LADI-5144]: https://uclalibrary.atlassian.net/browse/LADI-5144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ