### PR TITLE
fix: LADI-5256 fix broken tutorial links

### DIFF
--- a/app/pages/help/tutorials/index.vue
+++ b/app/pages/help/tutorials/index.vue
@@ -107,7 +107,7 @@ const parsedTutorialsList = computed(() => {
       image: _get(obj, 'image[0]', null),
       category: stringifyTutorialTypes, // For SectionTeaserCard field
       tutorialCategory: groupTutorialCategoryTitles,
-      to: tutorialPath ? `/${tutorialPath.replace(/^\/+/, '')}` : ''
+      to: tutorialPath ? `/${tutorialPath.replace(/^\/+/, '')}` : '' // normalize links by adding '/' before the path
     }
   })
 

--- a/app/pages/help/tutorials/index.vue
+++ b/app/pages/help/tutorials/index.vue
@@ -101,12 +101,13 @@ const parsedTutorialsList = computed(() => {
     const stringifyTutorialTypes = obj.tutorialType?.map(item => item.title).join(', ')
 
     const groupTutorialCategoryTitles = obj.tutorialCategory?.map(item => item.title)
-
+    const tutorialPath = obj.to || obj.uri
     return {
       ...obj,
       image: _get(obj, 'image[0]', null),
       category: stringifyTutorialTypes, // For SectionTeaserCard field
-      tutorialCategory: groupTutorialCategoryTitles
+      tutorialCategory: groupTutorialCategoryTitles,
+      to: tutorialPath ? `/${tutorialPath.replace(/^\/+/, '')}` : ''
     }
   })
 


### PR DESCRIPTION
#### Connected to [LADI-5256](https://jira.library.ucla.edu/browse/LADI-5256)

#### Deployed on https://deploy-preview-941--uclalibrary-test.netlify.app/

---

### Notes

This was happening because some links didn't include '/' in front of them. I've added a snipped to ensure its' there

https://deploy-preview-941--uclalibrary-test.netlify.app/help/tutorials/
links now work correctly

---

## Checklist

### Author
- [X] Browsers
    - [X] Review PR in Chrome, Firefox, Safari, Edge
    - [X] Review PR in desktop view, tablet view, mobile view
- [X] A11Y
    - [X] Zoom the site to 200%
    - [X] Check for keyboard traps
- [X] Design & Code
    - [X] Check that it looks like the design(s) _(if applicable)_
    - [X] Include a working / updated spec file _(if applicable)_

### UX Review
- [ ] UX has reviewed and approved

### Dev Review
  - [ ] Review Chromatic
  - [ ] Review the deploy preview
  - [ ] Review the code


[LADI-5256]: https://uclalibrary.atlassian.net/browse/LADI-5256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ