### PR TITLE
fix: LADI-5274 Fix staff directory link on location detail page

### DIFF
--- a/app/pages/visit/locations/[slug].vue
+++ b/app/pages/visit/locations/[slug].vue
@@ -77,7 +77,7 @@ const parsedStaffDirectory = computed(() => {
     const searchLibrary = page.value.title
     const libConcat =
       '/about/staff/?q=&filters=locations.title.keyword:(' +
-      searchLibrary.replaceAll(' ', '+') +
+      searchLibrary.replaceAll(' ', '+').replaceAll('&', '%26') +
       ')'
 
     return libConcat
@@ -85,6 +85,7 @@ const parsedStaffDirectory = computed(() => {
     return ''
   }
 })
+console.log('parsedStaffDirectory: ', parsedStaffDirectory.value)
 
 const parsedAddress = computed(() => {
   if (page.value.address.length && page.value.address[0].addressLine2) {

--- a/app/pages/visit/locations/[slug].vue
+++ b/app/pages/visit/locations/[slug].vue
@@ -85,7 +85,6 @@ const parsedStaffDirectory = computed(() => {
     return ''
   }
 })
-console.log('parsedStaffDirectory: ', parsedStaffDirectory.value)
 
 const parsedAddress = computed(() => {
   if (page.value.address.length && page.value.address[0].addressLine2) {


### PR DESCRIPTION
#### Connected to [LADI-5274](https://jira.library.ucla.edu/browse/LADI-5274)

#### Deployed on: https://deploy-preview-943--uclalibrary-test.netlify.app/visit/locations/arsc/

### Notes

- `&` in directory link is treated as a query string separator which creates empty results
- Updated parsing to replace ampersand with url-encoded value `%26`
- Created test location entry in test craft to verify change: `visit/locations/arsc/`

### Screenshots

**Before**
<kbd>
<img width="600" height="400" alt="before" src="https://github.com/user-attachments/assets/e02fff30-b6b1-40df-82c8-f6d0c04523bb" />
</kbd>

**After**
<kbd>
<img width="600" height="556" alt="after" src="https://github.com/user-attachments/assets/68dc40d4-2f62-4279-9f8a-b4b034865cc9" />
</kbd>

---

## Checklist

### Author
- [x] Browsers
    - [x] Review PR in Chrome, Firefox, Safari, Edge
    - ~~[ ] Review PR in desktop view, tablet view, mobile view~~
- ~~[ ] A11Y~~
    - ~~[ ] Zoom the site to 200%~~
    - ~~[ ] Check for keyboard traps~~
- ~~[ ] Design & Code~~
    - ~~[ ] Check that it looks like the design(s) _(if applicable)_~~
    - ~~[ ] Include a working / updated spec file _(if applicable)_~~
    - ~~[ ] Review the Chromatic _(if the PR is large and requires it)_~~

### UX Review
- [x] UX has reviewed and approved

### Dev Review
  - [ ] Review Chromatic
  - [ ] Review the deploy preview
  - [ ] Review the code


[LADI-5274]: https://uclalibrary.atlassian.net/browse/LADI-5274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ