### PR TITLE
fix: LADI-5258 Resize H5P Embed on Tutorial Pages

### DIFF
--- a/app/pages/help/tutorials/[slug].vue
+++ b/app/pages/help/tutorials/[slug].vue
@@ -65,7 +65,8 @@ useHead({
       name: 'description',
       content: metaDescription.value
     }
-  ]
+  ],
+  script: [{ src: "https://uclabruinlearn.h5p.com/js/h5p-resizer.js", defer: true }],
 })
 
 const parsedButtonText = computed(() => {

--- a/app/pages/help/tutorials/[slug].vue
+++ b/app/pages/help/tutorials/[slug].vue
@@ -66,7 +66,7 @@ useHead({
       content: metaDescription.value
     }
   ],
-  script: [{ src: "https://uclabruinlearn.h5p.com/js/h5p-resizer.js", defer: true }],
+  script: [{ src: 'https://uclabruinlearn.h5p.com/js/h5p-resizer.js', defer: true }],
 })
 
 const parsedButtonText = computed(() => {


### PR DESCRIPTION
#### Connected to [LADI-5258](https://jira.library.ucla.edu/browse/LADI-5258)

#### Deployed Preview:

- https://deploy-preview-944--uclalibrary-test.netlify.app/help/tutorials/long-h5p-canvas-positionality-research/
- https://deploy-preview-944--uclalibrary-test.netlify.app/help/tutorials/using-simpsons-diversity-index/

- [Before](https://deploy-preview-943--uclalibrary-test.netlify.app/help/tutorials/long-h5p-canvas-positionality-research/)

### Notes

- Added link to resizer script to useHead composable on Tutorial slug page

### Screenshot

**Before**
<kbd>
<img width="500" height="270" alt="before" src="https://github.com/user-attachments/assets/09dc7b67-2c56-4994-b227-9fbf92a20695" />
</kbd>

<br>

**After**
<kbd>
<img width="500" height="420" alt="after" src="https://github.com/user-attachments/assets/314c6a4f-c614-4d46-820f-cb16735289b5" />
</kbd>

---

## Checklist

### Author
- [x] Browsers
    - [x] Review PR in Chrome, Firefox, Safari, Edge
    - [x] Review PR in desktop view, tablet view, mobile view
- [x] A11Y
    - [x] Zoom the site to 200%
    - [x] Check for keyboard traps
- ~~[ ] Design & Code~~
    - ~~[ ] Check that it looks like the design(s) _(if applicable)_~~
    - ~~[ ] Include a working / updated spec file _(if applicable)_~~
    - ~~[ ] Review the Chromatic _(if the PR is large and requires it)_~~

### UX Review
- [x] UX has reviewed and approved

### Dev Review
  - [ ] Review Chromatic
  - [ ] Review the deploy preview
  - [ ] Review the code


[LADI-5258]: https://uclalibrary.atlassian.net/browse/LADI-5258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ