### PR TITLE
feat: LADI-5261 remove spacing around videos inside rich text

### DIFF
--- a/app/assets/styles/global.scss
+++ b/app/assets/styles/global.scss
@@ -150,7 +150,7 @@ button {
 
 // Only the library site removes spacing around videos inside Rich-Text (LADI-5261)
 :deep(.rich-text) {
-    video {
+    figure:has(video){
         margin: 0;
     }
 }

--- a/app/assets/styles/global.scss
+++ b/app/assets/styles/global.scss
@@ -150,7 +150,7 @@ button {
 
 // Only the library site removes spacing around videos inside Rich-Text (LADI-5261)
 :deep(.rich-text) {
-    figure:has(video){
+    figure:has(iframe){
         margin: 0;
     }
 }

--- a/app/assets/styles/global.scss
+++ b/app/assets/styles/global.scss
@@ -147,3 +147,10 @@ button {
 .visually-hidden {
     @include visually-hidden;
 }
+
+// Only the library site removes spacing around videos inside Rich-Text (LADI-5261)
+:deep(.rich-text) {
+    video {
+        margin: 0;
+    }
+}


### PR DESCRIPTION
#### Connected to [LADI-5261](https://jira.library.ucla.edu/browse/LADI-5261)

#### Deployed on https://deploy-preview-945--uclalibrary-test.netlify.app/

---

### Notes

This style is specific to the library site, but we don't have a library theme (we have a default theme that affects both the library and the MEAP site)

So I have added it to the global.css for the library site for now. 

Before:
https://uclalibrary-test.library.ucla.edu/help/tutorials/dna-replication-mechanism/

After:
https://deploy-preview-945--uclalibrary-test.netlify.app/help/tutorials/dna-replication-mechanism/

---

## Checklist

### Author
- [ ] Browsers
    - [ ] Review PR in Chrome, Firefox, Safari, Edge
    - [ ] Review PR in desktop view, tablet view, mobile view
- [ ] A11Y
    - [ ] Zoom the site to 200%
    - [ ] Check for keyboard traps
- [ ] Design & Code
    - [ ] Check that it looks like the design(s) _(if applicable)_
    - [ ] Include a working / updated spec file _(if applicable)_
    - [ ] Review the Chromatic _(if the PR is large and requires it)_

### UX Review
- [ ] UX has reviewed and approved

### Dev Review
  - [ ] Review Chromatic
  - [ ] Review the deploy preview
  - [ ] Review the code


[LADI-5261]: https://uclalibrary.atlassian.net/browse/LADI-5261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ