### PR TITLE
feat: LADI-5275 remove learning outcomes

### DIFF
--- a/app/pages/help/tutorials/[slug].vue
+++ b/app/pages/help/tutorials/[slug].vue
@@ -154,26 +154,6 @@ const parsedBlockCTA2Up = computed(() => {
       :to="parsedButtonTo"
     />
 
-    <SectionWrapper
-      v-if="page.learningOutcomes"
-      theme="divider"
-    >
-      <DividerWayFinder
-        class="divider"
-        color="help"
-      />
-    </SectionWrapper>
-
-    <SectionWrapper
-      v-if="page.learningOutcomes"
-      section-title="Learning Outcomes"
-    >
-      <RichText
-        class="learning-outcomes"
-        :rich-text-content="page.learningOutcomes"
-      />
-    </SectionWrapper>
-
     <FlexibleBlocks
       v-if="page && page.blocks"
       class="flexible-content"

--- a/gql/queries/TutorialsDetail.gql
+++ b/gql/queries/TutorialsDetail.gql
@@ -26,7 +26,6 @@ query TutorialDetail($slug: [String!]) {
     tutorialCategory {
       title
     }
-    learningOutcomes: richTextDefault
     ...AllFpb
 
     resourceServiceWorkshop {


### PR DESCRIPTION
#### Connected to [LADI-5275](https://jira.library.ucla.edu/browse/LADI-5275)

#### Deployed on https://deploy-preview-946--uclalibrary-test.netlify.app/

---

### Notes

Quick one since we're removing: I just deleted the section for learning outcomes and the corresponding GQL.

If anyone can think of anywhere else this GQL was planned for use please let us all know. 

This data has been removed from craft but you can see it in older links:
https://deploy-preview-926--uclalibrary-test.netlify.app/help/tutorials/electron-configurations/

new links:
https://deploy-preview-946--uclalibrary-test.netlify.app/help/tutorials/electron-configurations/
 
---

## Checklist

### Author
- [X] Browsers
    - [X] Review PR in Chrome, Firefox, Safari, Edge
    - [X] Review PR in desktop view, tablet view, mobile view
- [X] A11Y
    - [X] Zoom the site to 200%
    - [X] Check for keyboard traps
- [X] Design & Code
    - [X] Check that it looks like the design(s) _(if applicable)_
    - [X] Include a working / updated spec file _(if applicable)_
    - ~~[ ] Review the Chromatic _(if the PR is large and requires it)_~~

### UX Review
- ~~[ ] UX has reviewed and approved~~ there is no visual component / this is tech debt so UX review is skipped

### Dev Review
  - [ ] Review Chromatic
  - [ ] Review the deploy preview
  - [ ] Review the code


[LADI-5275]: https://uclalibrary.atlassian.net/browse/LADI-5275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ