### PR TITLE
fix: LADI-5276 Remove PageAnchor "More Info" Text

### DIFF
--- a/app/plugins/get-headers.client.js
+++ b/app/plugins/get-headers.client.js
@@ -8,7 +8,7 @@ function getHeadersMethod() {
   const h2Array = []
 
   elements.forEach((element) => {
-    if (element.textContent !== 'More Information') {
+    if (element.textContent.trim() !== 'More Information') {
       h2Array.push(element.textContent)
     }
   })


### PR DESCRIPTION
#### Connected to [LADI-5276](https://jira.library.ucla.edu/browse/LADI-5276)

#### Deployed preview: 

- https://deploy-preview-948--uclalibrary-test.netlify.app/collections/
- Before: https://deploy-preview-946--uclalibrary-test.netlify.app/collections/

### Notes

- Trimmed off whitespace that was causing the visually hidden header text ("More Information") to fail the getHeader plugin logic and appear in the headers list

### Screenshot

**Before**
<kbd>
<img width="535" height="190" alt="before" src="https://github.com/user-attachments/assets/e4c8e7da-5056-4287-980a-fa8249d58049" />
</kbd>

**After**
<kbd>
<img width="535" height="175" alt="after" src="https://github.com/user-attachments/assets/5f8a1c0c-6064-49d5-9cfb-909514ae5b6e" />
</kbd>

---

## Checklist

### Author
- [x] Browsers
    - [x] Review PR in Chrome, Firefox, Safari, Edge
    - [x] Review PR in desktop view, tablet view, mobile view
- ~~[ ] A11Y~~
    - ~~[ ] Zoom the site to 200%~~
    - ~~[ ] Check for keyboard traps~~
- ~~[ ] Design & Code~~
    - ~~[ ] Check that it looks like the design(s) _(if applicable)_~~
    - ~~[ ] Include a working / updated spec file _(if applicable)_~~
    - ~~[ ] Review the Chromatic _(if the PR is large and requires it)_~~

### UX Review
- [ ] UX has reviewed and approved

### Dev Review
  - [ ] Review Chromatic
  - [ ] Review the deploy preview
  - [ ] Review the code


[LADI-5276]: https://uclalibrary.atlassian.net/browse/LADI-5276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ